### PR TITLE
Disable building withers

### DIFF
--- a/pandamium_datapack/data/minecraft/tags/block/wither_summon_base_blocks.json
+++ b/pandamium_datapack/data/minecraft/tags/block/wither_summon_base_blocks.json
@@ -1,0 +1,1 @@
+{"replace":true,"values":[]}


### PR DESCRIPTION
Building a wither structure will not spawn the wither in, but still keep the structure in place. No blocks are recognised