### PR TITLE
spawnpoint trigger for staff team

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -27,3 +27,4 @@ execute if score @s tpa_accept matches 1.. run function pandamium:triggers/tpa_a
 execute if score @s tpa_accept matches ..-1 run function pandamium:triggers/tpa_accept
 execute if score @s show_homes matches 1.. run function pandamium:triggers/show_homes
 execute if score @s warp_staff_room matches 1.. run function pandamium:triggers/warp_staff_room
+execute if score @s spawnpoint matches 1.. run function pandamium:triggers/spawnpoint

--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -26,4 +26,6 @@ execute as @a if score @s jailed matches 1.. unless data entity @s {Dimension:0}
 execute as @a if score @s jailed matches 1.. unless entity @s[x=-6,y=57,z=-6,dx=12,dy=4,dz=12] run tp @s 3 57 0
 execute as @a[x=-6,y=57,z=-6,dx=12,dy=4,dz=12] unless score @s jailed matches 1.. unless score @s staff_perms matches 1.. run scoreboard players set @s spawn 1
 
+execute as @a run function pandamium:misc/spawnpoint_refresh
+
 schedule function pandamium:main_loop 5t

--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -26,6 +26,6 @@ execute as @a if score @s jailed matches 1.. unless data entity @s {Dimension:0}
 execute as @a if score @s jailed matches 1.. unless entity @s[x=-6,y=57,z=-6,dx=12,dy=4,dz=12] run tp @s 3 57 0
 execute as @a[x=-6,y=57,z=-6,dx=12,dy=4,dz=12] unless score @s jailed matches 1.. unless score @s staff_perms matches 1.. run scoreboard players set @s spawn 1
 
-execute as @a run function pandamium:misc/spawnpoint_refresh
+execute as @a if data entity @s SpawnX run function pandamium:misc/spawnpoint_refresh
 
 schedule function pandamium:main_loop 5t

--- a/pandamium_datapack/data/pandamium/functions/misc/spawnpoint_refresh.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/spawnpoint_refresh.mcfunction
@@ -1,0 +1,6 @@
+execute if data entity @s SpawnX store result score @s spawnpoint_x run data get entity @s SpawnX
+execute if data entity @s SpawnY store result score @s spawnpoint_y run data get entity @s SpawnY
+execute if data entity @s SpawnZ store result score @s spawnpoint_z run data get entity @s SpawnZ
+execute if data entity @s SpawnDimension if entity @s[nbt={Dimension:"minecraft:the_nether"}] run scoreboard players set @s spawn_dimension -1
+execute if data entity @s SpawnDimension if entity @s[nbt={Dimension:"minecraft:overworld"}] run scoreboard players set @s spawn_dimension 0
+execute if data entity @s SpawnDimension if entity @s[nbt={Dimension:"minecraft:the_end"}] run scoreboard players set @s spawn_dimension 1

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -1,8 +1,6 @@
 execute unless score @s id matches 1.. run function pandamium:misc/assign_id
 execute as @s run function pandamium:misc/update_teams
 
-function pandamium:misc/spawnpoint_refresh
-
 scoreboard players reset @s[scores={gameplay_perms=3..}] home_cooldown
 scoreboard players reset @s[scores={gameplay_perms=3..}] tpa_cooldown
 execute if score @s particles matches 1.. unless score @s gameplay_perms matches 3.. run scoreboard players set @s particles 0

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -1,6 +1,8 @@
 execute unless score @s id matches 1.. run function pandamium:misc/assign_id
 execute as @s run function pandamium:misc/update_teams
 
+function pandamium:misc/spawnpoint_refresh
+
 scoreboard players reset @s[scores={gameplay_perms=3..}] home_cooldown
 scoreboard players reset @s[scores={gameplay_perms=3..}] tpa_cooldown
 execute if score @s particles matches 1.. unless score @s gameplay_perms matches 3.. run scoreboard players set @s particles 0

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -26,6 +26,7 @@ execute if score @s staff_perms matches 1.. run scoreboard players enable @s end
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s get_guidebook
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s show_homes
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s warp_staff_room
+execute if score @s staff_perms matches 1.. run scoreboard players enable @s spawnpoint
 
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s kick
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s ban

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -41,6 +41,13 @@ scoreboard objectives add get_guidebook trigger
 scoreboard objectives add show_homes trigger
 scoreboard objectives add warp_staff_room trigger
 
+scoreboard objectives add spawnpoint trigger
+scoreboard objectives add spawnpoint_x dummy
+scoreboard objectives add spawnpoint_y dummy
+scoreboard objectives add spawnpoint_z dummy
+scoreboard objectives add spawnpoint_dim dummy
+scoreboard objectives add time_since_rest minecraft.custom:time_since_rest
+
 scoreboard objectives add votes dummy
 scoreboard objectives add vote_credits dummy
 
@@ -105,6 +112,7 @@ scoreboard players reset * in_nether_spawn
 scoreboard players reset * temp_1
 scoreboard players reset * temp_2
 scoreboard players reset * temp_3
+scoreboard players reset * spawnpoint
 
 team add guest
 team modify guest prefix "Guest | "

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -46,7 +46,6 @@ scoreboard objectives add spawnpoint_x dummy
 scoreboard objectives add spawnpoint_y dummy
 scoreboard objectives add spawnpoint_z dummy
 scoreboard objectives add spawnpoint_dim dummy
-scoreboard objectives add time_since_rest minecraft.custom:time_since_rest
 
 scoreboard objectives add votes dummy
 scoreboard objectives add vote_credits dummy

--- a/pandamium_datapack/data/pandamium/functions/triggers/spawnpoint.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/spawnpoint.mcfunction
@@ -1,0 +1,16 @@
+execute at @a if score @s spawnpoint = @p id unless score @p spawnpoint_x = @p spawnpoint_x run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"}," has not set a spawnpoint."]
+
+execute at @a if score @s spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches -1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Nether."]
+execute at @a if score @s spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches 0 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Overworld."]
+execute at @a if score @s spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches 1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current  spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the End."]
+
+execute at @a if score @s spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches -1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Nether."]
+execute at @a if score @s spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches 0 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Overworld."]
+execute at @a if score @s spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches 1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the End."]
+
+execute if score @s spawnpoint matches -2 run scoreboard players set @s spawnpoint -3
+execute at @a if score @s spawnpoint = @p id run scoreboard players set @s spawnpoint -2
+execute unless score @s spawnpoint matches -2 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"}, "Could not find a player with that id."]
+
+scoreboard players reset @s spawnpoint
+scoreboard players enable @s spawnpoint


### PR DESCRIPTION
- staff with `staff_perms=1..` can use `/trigger spawnpoint set <ID>` to see the current or last spawnpoint of an online player.
- Players' spawnpoint values update every 5 ticks as there is no simple to detect a player setting their spawnpoint with a respawn anchor. 