### PR TITLE
Added Blocks from Slabs recipes and advancements

### DIFF
--- a/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_nether_bricks.json
+++ b/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_nether_bricks.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:chiseled_nether_bricks"
+    ]
+  },
+  "criteria": {
+    "has_nether_bricks_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:nether_brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_nether_bricks_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_polished_blackstone.json
+++ b/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_polished_blackstone.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:chiseled_polished_blackstone"
+    ]
+  },
+  "criteria": {
+    "has_polished_blackstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:polished_blackstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_polished_blackstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_quartz_block.json
+++ b/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_quartz_block.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:chiseled_quartz_block"
+    ]
+  },
+  "criteria": {
+    "has_quartz_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:quartz_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_quartz_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_red_sandstone.json
+++ b/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_red_sandstone.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:chiseled_red_sandstone"
+    ]
+  },
+  "criteria": {
+    "has_red_sandstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:red_sandstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_red_sandstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_sandstone.json
+++ b/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_sandstone.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:chiseled_sandstone"
+    ]
+  },
+  "criteria": {
+    "has_sandstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:sandstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_sandstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_stone_bricks.json
+++ b/pandamium_datapack/data/minecraft/advancements/recipes/building_blocks/chiseled_stone_bricks.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "minecraft:chiseled_stone_bricks"
+    ]
+  },
+  "criteria": {
+    "has_stone_brick_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:stone_brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone_brick_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/minecraft/recipes/chiseled_nether_bricks.json
+++ b/pandamium_datapack/data/minecraft/recipes/chiseled_nether_bricks.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:nether_brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:nether_bricks"
+  }
+}

--- a/pandamium_datapack/data/minecraft/recipes/chiseled_polished_blackstone.json
+++ b/pandamium_datapack/data/minecraft/recipes/chiseled_polished_blackstone.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:polished_blackstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:polished_blackstone"
+  }
+}

--- a/pandamium_datapack/data/minecraft/recipes/chiseled_quartz_block.json
+++ b/pandamium_datapack/data/minecraft/recipes/chiseled_quartz_block.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:quartz_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:quartz_block"
+  }
+}

--- a/pandamium_datapack/data/minecraft/recipes/chiseled_red_sandstone.json
+++ b/pandamium_datapack/data/minecraft/recipes/chiseled_red_sandstone.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:red_sandstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:red_sandstone"
+  }
+}

--- a/pandamium_datapack/data/minecraft/recipes/chiseled_sandstone.json
+++ b/pandamium_datapack/data/minecraft/recipes/chiseled_sandstone.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:sandstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:sandstone"
+  }
+}

--- a/pandamium_datapack/data/minecraft/recipes/chiseled_stone_bricks.json
+++ b/pandamium_datapack/data/minecraft/recipes/chiseled_stone_bricks.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone_brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:stone_bricks"
+  }
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/acacia_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/acacia_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:acacia_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_acacia_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:acacia_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_acacia_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/andesite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/andesite_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:andesite_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_andesite_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:andesite_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_andesite_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/birch_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/birch_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:birch_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_birch_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:birch_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_birch_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/blackstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/blackstone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:blackstone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_blackstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:blackstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_blackstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/bricks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:bricks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_brick_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_brick_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cobblestone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cobblestone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:cobblestone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_cobblestone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:cobblestone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_cobblestone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cobblestone_from_stone_stonecutting.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cobblestone_from_stone_stonecutting.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:cobblestone_from_stone_stonecutting"
+    ]
+  },
+  "criteria": {
+    "has_stone": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:stone"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/crimson_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/crimson_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:crimson_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_crimson_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:crimson_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_crimson_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cut_red_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cut_red_sandstone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:cut_red_sandstone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_cut_red_sandstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:cut_red_sandstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_cut_red_sandstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cut_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cut_sandstone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:cut_sandstone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_cut_sandstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:cut_sandstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_cut_sandstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/dark_oak_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/dark_oak_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:dark_oak_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_dark_oak_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:dark_oak_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_dark_oak_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/dark_prismarine_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/dark_prismarine_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:dark_prismarine_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_dark_prismarine_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:dark_prismarine_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_dark_prismarine_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/diorite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/diorite_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:diorite_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_diorite_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:diorite_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_diorite_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/end_stone_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/end_stone_bricks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:end_stone_bricks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_end_stone_brick_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:end_stone_brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_end_stone_brick_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/granite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/granite_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:granite_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_granite_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:granite_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_granite_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/jungle_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/jungle_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:jungle_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_jungle_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:jungle_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_jungle_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/mossy_cobblestone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/mossy_cobblestone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:mossy_cobblestone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_mossy_cobblestone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:mossy_cobblestone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_mossy_cobblestone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/mossy_stone_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/mossy_stone_bricks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:mossy_stone_bricks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_mossy_stone_brick_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:mossy_stone_brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_mossy_stone_brick_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/oak_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/oak_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:oak_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_oak_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:oak_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_oak_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_andesite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_andesite_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:polished_andesite_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_polished_andesite_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:polished_andesite_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_polished_andesite_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_blackstone_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_blackstone_bricks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:polished_blackstone_bricks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_polished_blackstone_brick_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:polished_blackstone_brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_polished_blackstone_brick_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_diorite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_diorite_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:polished_diorite_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_polished_diorite_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:polished_diorite_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_polished_diorite_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_granite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/polished_granite_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:polished_granite_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_polished_granite_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:polished_granite_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_polished_granite_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/prismarine_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/prismarine_bricks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:prismarine_bricks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_prismarine_brick_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:prismarine_brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_prismarine_brick_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/prismarine_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/prismarine_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:prismarine_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_prismarine_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:prismarine_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_prismarine_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/purpur_block_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/purpur_block_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:purpur_block_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_purpur_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:purpur_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_purpur_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/red_nether_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/red_nether_bricks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:red_nether_bricks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_red_nether_brick_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:red_nether_brick_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_red_nether_brick_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_quartz_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_quartz_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:smooth_quartz_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_smooth_quartz_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:smooth_quartz_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_smooth_quartz_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_red_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_red_sandstone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:smooth_red_sandstone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_smooth_red_sandstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:smooth_red_sandstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_smooth_red_sandstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_sandstone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:smooth_sandstone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_smooth_sandstone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:smooth_sandstone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_smooth_sandstone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_stone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/smooth_stone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:smooth_stone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_smooth_stone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:smooth_stone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_smooth_stone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/spruce_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/spruce_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:spruce_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_spruce_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:spruce_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_spruce_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/stone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/stone_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:stone_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_stone_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:stone_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_stone_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/warped_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/warped_planks_from_slabs.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:warped_planks_from_slabs"
+    ]
+  },
+  "criteria": {
+    "has_warped_slab": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:warped_slab"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_warped_slab"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/recipes/acacia_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/acacia_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:acacia_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:acacia_planks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/andesite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/andesite_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:andesite_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:andesite",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/birch_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/birch_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:birch_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:birch_planks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/blackstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/blackstone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:blackstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:blackstone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/bricks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:bricks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/cobblestone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/cobblestone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:cobblestone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:cobblestone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/cobblestone_from_stone_stonecutting.json
+++ b/pandamium_datapack/data/pandamium/recipes/cobblestone_from_stone_stonecutting.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "ingredient": {
+    "item": "minecraft:stone"
+  },
+  "result": "minecraft:cobblestone",
+  "count": 1
+}

--- a/pandamium_datapack/data/pandamium/recipes/crimson_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/crimson_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:crimson_planks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/cut_red_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/cut_red_sandstone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:cut_red_sandstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:cut_red_sandstone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/cut_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/cut_sandstone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:cut_sandstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:cut_sandstone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/dark_oak_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/dark_oak_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_oak_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_oak_planks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/dark_prismarine_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/dark_prismarine_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dark_prismarine_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:dark_prismarine",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/diorite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/diorite_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:diorite_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:diorite",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/end_stone_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/end_stone_bricks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:end_stone_brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:end_stone_bricks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/granite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/granite_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:granite_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:granite",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/jungle_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/jungle_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:jungle_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:jungle_planks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/mossy_cobblestone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/mossy_cobblestone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:mossy_cobblestone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:mossy_cobblestone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/mossy_stone_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/mossy_stone_bricks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:mossy_stone_brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:mossy_stone_bricks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/oak_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/oak_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:oak_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:oak_planks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/polished_andesite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/polished_andesite_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:polished_andesite_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:polished_andesite",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/polished_blackstone_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/polished_blackstone_bricks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:polished_blackstone_brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:polished_blackstone_bricks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/polished_diorite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/polished_diorite_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:polished_diorite_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:polished_diorite",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/polished_granite_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/polished_granite_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:polished_granite_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:polished_granite",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/prismarine_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/prismarine_bricks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:prismarine_brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:prismarine_bricks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/prismarine_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/prismarine_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:prismarine_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:prismarine",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/purpur_block_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/purpur_block_from_slabs.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:purpur_slab"
+      }
+    ]
+  },
+  "result": {
+    "item": "minecraft:purpur_block",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/red_nether_bricks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/red_nether_bricks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:red_nether_brick_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:red_nether_bricks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/smooth_quartz_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/smooth_quartz_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:smooth_quartz_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:smooth_quartz",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/smooth_red_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/smooth_red_sandstone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:smooth_red_sandstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:smooth_red_sandstone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/smooth_sandstone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/smooth_sandstone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:smooth_sandstone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:smooth_sandstone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/smooth_stone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/smooth_stone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:smooth_stone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:smooth_stone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/spruce_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/spruce_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:spruce_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:spruce_planks",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/stone_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/stone_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:stone",
+    "count": 1
+  }
+}

--- a/pandamium_datapack/data/pandamium/recipes/warped_planks_from_slabs.json
+++ b/pandamium_datapack/data/pandamium/recipes/warped_planks_from_slabs.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "group": "double_slab_blocks",
+  "pattern": [
+    "#",
+	"#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_slab"
+    }
+  },
+  "result": {
+    "item": "minecraft:warped_planks",
+    "count": 1
+  }
+}


### PR DESCRIPTION
placing 2 of the same type slabs above each other in a crafting grid will output the full block form
recipes are learnt once the slab is in the player's inventory
the recipes are grouped together within the building blocks tab
![slabs_recipes_treated](https://user-images.githubusercontent.com/16517352/85930588-9c5aa900-b8b5-11ea-83f2-993031c3bae4.gif)
