### PR TITLE
Consitency changes for spawnpoint (show_spawnpoint) trigger and show_homes trigger

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -27,7 +27,7 @@ execute if score @s tpa_accept matches 1.. run function pandamium:triggers/tpa_a
 execute if score @s tpa_accept matches ..-1 run function pandamium:triggers/tpa_accept
 execute if score @s show_homes matches 1.. run function pandamium:triggers/show_homes
 execute if score @s warp_staff_room matches 1.. run function pandamium:triggers/warp_staff_room
-execute if score @s spawnpoint matches 1.. run function pandamium:triggers/spawnpoint
+execute if score @s show_spawnpoint matches 1.. run function pandamium:triggers/spawnpoint
 execute if score @s tp matches 1.. run function pandamium:triggers/tp
 execute if score @s top_playtime matches 1.. run function pandamium:triggers/top_playtime
 execute if score @s top_votes matches 1.. run function pandamium:triggers/top_votes

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -29,7 +29,7 @@ execute if score @s staff_perms matches 1.. run scoreboard players enable @s end
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s get_guidebook
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s show_homes
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s warp_staff_room
-execute if score @s staff_perms matches 1.. run scoreboard players enable @s spawnpoint
+execute if score @s staff_perms matches 1.. run scoreboard players enable @s show_spawnpoint
 
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s kick
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s ban

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -45,7 +45,7 @@ scoreboard objectives add warp_staff_room trigger
 scoreboard objectives add tp trigger
 scoreboard objectives add take_ec trigger
 scoreboard objectives add take_inv trigger
-scoreboard objectives add spawnpoint trigger
+scoreboard objectives add show_spawnpoint trigger
 
 scoreboard objectives add spawnpoint_x dummy
 scoreboard objectives add spawnpoint_y dummy

--- a/pandamium_datapack/data/pandamium/functions/triggers/show_homes.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/show_homes.mcfunction
@@ -1,3 +1,5 @@
+execute if score @s show_homes matches 1 run scoreboard players operation @s show_homes = @s id
+
 execute at @a if score @s show_homes = @p id run function pandamium:misc/list_homes
 
 scoreboard players reset @s show_homes

--- a/pandamium_datapack/data/pandamium/functions/triggers/spawnpoint.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/spawnpoint.mcfunction
@@ -1,16 +1,18 @@
-execute at @a if score @s spawnpoint = @p id unless score @p spawnpoint_x = @p spawnpoint_x run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"}," has not set a spawnpoint."]
+execute if score @s show_spawnpoint matches 1 run scoreboard players operation @s show_spawnpoint = @s id
 
-execute at @a if score @s spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches -1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Nether."]
-execute at @a if score @s spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches 0 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Overworld."]
-execute at @a if score @s spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches 1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current  spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the End."]
+execute at @a if score @s show_spawnpoint = @p id unless score @p spawnpoint_x = @p spawnpoint_x run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"}," has not set a spawnpoint."]
 
-execute at @a if score @s spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches -1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Nether."]
-execute at @a if score @s spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches 0 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Overworld."]
-execute at @a if score @s spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches 1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the End."]
+execute at @a if score @s show_spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches -1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Nether."]
+execute at @a if score @s show_spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches 0 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Overworld."]
+execute at @a if score @s show_spawnpoint = @p id if data entity @s SpawnX if score @p spawnpoint_dim matches 1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s current  spawnpoint is at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the End."]
 
-execute if score @s spawnpoint matches -2 run scoreboard players set @s spawnpoint -3
-execute at @a if score @s spawnpoint = @p id run scoreboard players set @s spawnpoint -2
-execute unless score @s spawnpoint matches -2 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"}, "Could not find a player with that id."]
+execute at @a if score @s show_spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches -1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Nether."]
+execute at @a if score @s show_spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches 0 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the Overworld."]
+execute at @a if score @s show_spawnpoint = @p id unless data entity @s SpawnX if score @p spawnpoint_dim matches 1 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"},{"selector":"@p"},"'s last spawnpoint was at ",{"score":{"name":"@p","objective":"spawnpoint_x"}}," ",{"score":{"name":"@p","objective":"spawnpoint_y"}}," ",{"score":{"name":"@p","objective":"spawnpoint_z"}}," in the End."]
 
-scoreboard players reset @s spawnpoint
-scoreboard players enable @s spawnpoint
+execute if score @s show_spawnpoint matches -2 run scoreboard players set @s show_spawnpoint -3
+execute at @a if score @s show_spawnpoint = @p id run scoreboard players set @s show_spawnpoint -2
+execute unless score @s show_spawnpoint matches -2 run tellraw @s [{"text":"[Spawnpoint] ","color":"green"}, "Could not find a player with that id."]
+
+scoreboard players reset @s show_spawnpoint
+scoreboard players enable @s show_spawnpoint


### PR DESCRIPTION
- trigger spawnpoint name change to `show_spawnpoint`, to be consistent with `show_cooldown`, `show_homes` and `show_playtime`
- if you do `/trigger show_spawnpoint`, it will show you your own spawnpoint
- if you do `/trigger show_homes`, it will show you your own homes