### PR TITLE
Dupe glitch fix

### DIFF
--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cobweb.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/cobweb.json
@@ -1,0 +1,25 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "pandamium:cobweb"
+    ]
+  },
+  "criteria": {
+    "has_cobweb": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:cobweb"
+          }
+        ]
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_cobweb"
+    ]
+  ]
+}

--- a/pandamium_datapack/data/pandamium/functions/slow_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/slow_loop.mcfunction
@@ -1,0 +1,4 @@
+
+execute as @e[type=piglin,nbt={IsBaby:1b}] run data merge entity @s {CanPickUpLoot:0b}
+
+schedule function pandamium:slow_loop 5s

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -1,3 +1,7 @@
+#temporary
+function pandamium:slow_loop
+
+#startup
 scoreboard objectives add id dummy
 execute unless score <next_id> variable matches 1.. run scoreboard players set <next_id> variable 1
 
@@ -191,7 +195,6 @@ team join gray_color Players:
 team join gray_color Entities:
 
 function pandamium:main_loop
-function pandamium:slow_loop
 
 scoreboard players set <ticks_per_hour> variable 72000
 

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -191,6 +191,7 @@ team join gray_color Players:
 team join gray_color Entities:
 
 function pandamium:main_loop
+function pandamium:slow_loop
 
 scoreboard players set <ticks_per_hour> variable 72000
 


### PR DESCRIPTION
Added slow_loop
- Every 5 seconds
- Prevents all baby piglins from picking up items `{CanPickUpLoot:0b}`
- Baby piglins cannot grow up into adult piglins, so no other command required