### PR TITLE
Fixed toggle spectator mode issues

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -14,6 +14,7 @@ execute as @a[scores={inventory=..-1,staff_perms=1..},limit=1] run function pand
 execute as @a[scores={enderchest=..-1,staff_perms=1..},limit=1] run function pandamium:triggers/enderchest_shulkers
 
 execute as @a[gamemode=spectator] unless score @s staff_perms matches 2.. unless entity @s[x=-512,z=-512,dx=1024,dz=1024] run function pandamium:misc/spawn_restriction
+execute as @a[gamemode=spectator] unless score @s staff_perms matches 2.. if entity @s[nbt={Dimension:"minecraft:the_end"}] run gamemode survival @s
 
 execute as @a[x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] run function pandamium:misc/spawn_effects
 

--- a/pandamium_datapack/data/pandamium/functions/misc/spawn_restriction.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/spawn_restriction.mcfunction
@@ -2,6 +2,9 @@
 execute store result score <tp_x> variable run data get entity @s Pos[0]
 execute store result score <tp_z> variable run data get entity @s Pos[2]
 
+execute unless score <tp_x> variable matches -512..512 run spectate
+execute unless score <tp_z> variable matches -512..512 run spectate
+
 execute if score <tp_x> variable matches ..-513 at @s run tp @s -512 ~ ~
 execute if score <tp_x> variable matches 513.. at @s run tp @s 512 ~ ~
 execute if score <tp_z> variable matches ..-513 at @s run tp @s ~ ~ -512

--- a/pandamium_datapack/data/pandamium/functions/triggers/toggle_spectator.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/toggle_spectator.mcfunction
@@ -4,8 +4,14 @@ execute if entity @s[gamemode=!spectator] run scoreboard players set <toggle_gam
 execute unless score @s staff_perms matches 2.. unless entity @s[x=-512,y=-256,z=-512,dx=1024,dy=1280,dz=1024] run scoreboard players set <toggle_gamemode> variable 0
 execute unless score @s staff_perms matches 2.. unless entity @s[x=-512,y=-256,z=-512,dx=1024,dy=1280,dz=1024] run tellraw @s [{"text":"","color":"red"},{"text":"[Info]","color":"dark_red"}," Helpers can only use this trigger at spawn."]
 
-execute if score <toggle_gamemode> variable matches 0 run gamemode survival @s
-execute if score <toggle_gamemode> variable matches 1 run gamemode spectator @s
+scoreboard players set <can_toggle_spectator> variable 0
+execute if score @s staff_perms matches 2.. run scoreboard players set <can_toggle_spectator> variable 1
+execute unless score @s staff_perms matches 2.. if entity @s[nbt={Dimension:"minecraft:overworld"}] run scoreboard players set <can_toggle_spectator> variable 1
+execute unless score @s staff_perms matches 2.. if entity @s[nbt={Dimension:"minecraft:the_nether"}] run scoreboard players set <can_toggle_spectator> variable 1
+
+execute if score <can_toggle_spectator> variable matches 1 if score <toggle_gamemode> variable matches 0 run gamemode survival @s
+execute if score <can_toggle_spectator> variable matches 1 if score <toggle_gamemode> variable matches 1 run gamemode spectator @s
+execute unless score <can_toggle_spectator> variable matches 1 run tellraw @s [{"text":"","color":"red"},{"text":"[Info]","color":"dark_red"}," You cannot use this trigger here."]
 
 scoreboard players reset @s toggle_spectator
 scoreboard players enable @s toggle_spectator

--- a/pandamium_datapack/data/pandamium/functions/triggers/toggle_spectator.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/toggle_spectator.mcfunction
@@ -1,5 +1,5 @@
 scoreboard players set <toggle_gamemode> variable 0
-execute if entity @s[gamemode=survival] run scoreboard players set <toggle_gamemode> variable 1
+execute if entity @s[gamemode=!spectator] run scoreboard players set <toggle_gamemode> variable 1
 
 execute unless score @s staff_perms matches 2.. unless entity @s[x=-512,y=-256,z=-512,dx=1024,dy=1280,dz=1024] run scoreboard players set <toggle_gamemode> variable 0
 execute unless score @s staff_perms matches 2.. unless entity @s[x=-512,y=-256,z=-512,dx=1024,dy=1280,dz=1024] run tellraw @s [{"text":"","color":"red"},{"text":"[Info]","color":"dark_red"}," Helpers can only use this trigger at spawn."]


### PR DESCRIPTION
Fixed: Staff cannot toggle spectator when in the nether spawn
Fixed: If the entity/player a helper is spectating teleports from spawn, the helper gets stuck "in limbo"
Changed: Helpers can no longer go into spectator in the end, only the nether and overworld (spawn protection)