### PR TITLE
Added TPA checks for staff world and jailed players

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/tpa/accept_request.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/accept_request.mcfunction
@@ -1,6 +1,11 @@
-tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[TPA]","color":"blue"}," You ",{"text":"accepted","color":"aqua"}," ",[{"selector":"@s"},"'s"]," TPA request!"]
-tellraw @s [{"text":"","color":"green"},{"text":"[TPA]","color":"blue"}," ",{"selector":"@p[tag=running_trigger]"}," ",{"text":"accepted","color":"aqua"}," your TPA request!"]
 
-tp @s @p[tag=running_trigger]
+execute as @p[tag=running_trigger] run function pandamium:tpa/check_can_accept
 
-scoreboard players reset @p[tag=running_trigger] tpa_request
+execute if score <can_accept> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You cannot accept TPA requests currently! ",{"text":"[X]","color":"dark_red","bold":true,"clickEvent":{"action":"run_command","value":"/trigger tpa set -2"},"hoverEvent":{"action":"show_text","contents":[{"text":"Deny Request","color":"dark_red"}]}}]
+
+execute if score <can_accept> variable matches 1 run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[TPA]","color":"blue"}," You ",{"text":"accepted","color":"aqua"}," ",[{"selector":"@s"},"'s"]," TPA request!"]
+execute if score <can_accept> variable matches 1 run tellraw @s [{"text":"","color":"green"},{"text":"[TPA]","color":"blue"}," ",{"selector":"@p[tag=running_trigger]"}," ",{"text":"accepted","color":"aqua"}," your TPA request!"]
+
+execute if score <can_accept> variable matches 1 run tp @s @p[tag=running_trigger]
+
+execute if score <can_accept> variable matches 1 run scoreboard players reset @p[tag=running_trigger] tpa_request

--- a/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
@@ -1,0 +1,7 @@
+scoreboard players set <can_accept> variable 1
+
+tag @s add checking_can_accept
+execute in pandamium:staff_world as @a[x=0,tag=checking_can_accept] run scoreboard players set <can_accept> variable 0
+tag @s remove checking_can_accept
+
+execute if score @s jailed matches 1.. run scoreboard players set <can_accept> variable 0

--- a/pandamium_datapack/data/pandamium/functions/tpa/check_cooldown.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/check_cooldown.mcfunction
@@ -1,9 +1,13 @@
 scoreboard players set <player_exists> variable 0
 execute as @a if score @p[tag=running_trigger] tpa = @s id run scoreboard players set <player_exists> variable 1
-execute if score <player_exists> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," Could not find that player."]
 
 scoreboard players set <has_sent_request> variable 0
 execute as @a if score @s tpa_request = @p[tag=running_trigger] id run scoreboard players set <has_sent_request> variable 1
-execute if score <has_sent_request> variable matches 1 as @a if score @p[tag=running_trigger] id = @s tpa_request run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You have already sent a TPA request to ",{"selector":"@s","color":"red"},"! ",{"text":"[X]","bold":true,"color":"gray","clickEvent":{"action":"run_command","value":"/trigger tpa set -3"},"hoverEvent":{"action":"show_text","contents":[{"text":"Cancel Request","color":"gray"}]}}]
 
-execute if score <has_sent_request> variable matches 0 as @a if score @p[tag=running_trigger] tpa = @s id run function pandamium:tpa/send_request
+execute as @a if score @p[tag=running_trigger] tpa = @s id run function pandamium:tpa/check_can_accept
+
+execute if score @p[tag=running_trigger] jailed matches 1.. run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You cannot use this trigger in jail!"]
+execute unless score @p[tag=running_trigger] jailed matches 1.. if score <has_sent_request> variable matches 1 as @a if score @p[tag=running_trigger] id = @s tpa_request run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You have already sent a TPA request to ",{"selector":"@s","color":"red"},"! ",{"text":"[X]","bold":true,"color":"gray","clickEvent":{"action":"run_command","value":"/trigger tpa set -3"},"hoverEvent":{"action":"show_text","contents":[{"text":"Cancel Request","color":"gray"}]}}]
+execute unless score @p[tag=running_trigger] jailed matches 1.. if score <has_sent_request> variable matches 0 if score <player_exists> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," Could not find that player."]
+execute unless score @p[tag=running_trigger] jailed matches 1.. if score <has_sent_request> variable matches 0 if score <player_exists> variable matches 1 if score <can_accept> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You cannot teleport to this player currently!"]
+execute unless score @p[tag=running_trigger] jailed matches 1.. if score <has_sent_request> variable matches 0 if score <player_exists> variable matches 1 if score <can_accept> variable matches 1 if score <has_sent_request> variable matches 0 as @a if score @p[tag=running_trigger] tpa = @s id run function pandamium:tpa/send_request


### PR DESCRIPTION
If a player is staff world: they cannot accept or receive TPA requests
If a player is jailed: they cannot send, accept or receive TPA requests

also reorganised error messages for check_cooldown function