### PR TITLE
Entities: red in sidebar past mob limit

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/sidebar.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/sidebar.mcfunction
@@ -1,5 +1,8 @@
 scoreboard players operation Players: sidebar = <player_count> variable
-execute store result score Entities: sidebar run execute if entity @e[type=!item,type=!item_frame,type=!painting,type=!armor_stand]
+execute store result score Entities: sidebar run execute if entity @e[type=!#pandamium:mob_limit_excluded]
 execute store result score Items: sidebar run execute if entity @e[type=item]
+
+execute if score <mob_count> variable < <mob_limit> variable run team join gray_color Entities:
+execute unless score <mob_count> variable < <mob_limit> variable run team join red_color Entities:
 
 schedule function pandamium:misc/sidebar 20t

--- a/pandamium_datapack/data/pandamium/functions/misc/toggle_mob_spawning.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/toggle_mob_spawning.mcfunction
@@ -1,3 +1,3 @@
-execute store result score <mob_count> variable run execute if entity @e[type=!item,type=!item_frame,type=!painting,type=!armor_stand]
+execute store result score <mob_count> variable run execute if entity @e[type=!#pandamium:mob_limit_excluded]
 execute if score <mob_count> variable < <mob_limit> variable run gamerule doMobSpawning true
 execute unless score <mob_count> variable < <mob_limit> variable run gamerule doMobSpawning false

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -224,6 +224,9 @@ team join gray_color Players:
 team join gray_color Entities:
 team join gray_color Items:
 
+team add red_color
+team modify red_color color red
+
 execute in pandamium:staff_world run forceload add -1 -1 0 0
 
 function pandamium:main_loop

--- a/pandamium_datapack/data/pandamium/tags/entity_types/mob_limit_excluded.json
+++ b/pandamium_datapack/data/pandamium/tags/entity_types/mob_limit_excluded.json
@@ -1,8 +1,11 @@
 {
   "replace": false,
   "values": [
+    "minecraft:area_effect_cloud",
     "minecraft:armor_stand",
     "minecraft:item",
-    "minecraft:item_frame"
+    "minecraft:item_frame",
+    "minecraft:leash_knot",
+    "minecraft:painting"
   ]
 }

--- a/pandamium_datapack/data/pandamium/tags/entity_types/mob_limit_excluded.json
+++ b/pandamium_datapack/data/pandamium/tags/entity_types/mob_limit_excluded.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:armor_stand",
+    "minecraft:item",
+    "minecraft:item_frame"
+  ]
+}


### PR DESCRIPTION
Once the mob limit is reached, `Entities:` appears red in the sidebar
Also, added `mob_limit_excluded` entity type tag