### PR TITLE
Spectator mode changes

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/home/go_run.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/home/go_run.mcfunction
@@ -1,2 +1,3 @@
 function pandamium:misc/teleport
+execute if entity @s[gamemode=spectator] unless entity @s[x=-512,z=-512,dx=1024,dz=1024] unless score @s staff_perms matches 2.. run gamemode survival
 tellraw @s [{"text":"","color":"green"},{"text":"[Home]","color":"dark_green"}," Teleported to ",[{"text":"Home ","color":"aqua"},{"score":{"name":"@s","objective":"home"}}],"!"]

--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -12,12 +12,13 @@ execute store result score <player_count> variable if entity @a
 execute as @a[scores={playtime_ticks=1..5}] run function pandamium:first_join
 execute as @a unless score @s leave_count matches 0 run function pandamium:on_join
 
+execute as @a[gamemode=spectator] unless score @s staff_perms matches 2.. unless entity @s[x=-512,z=-512,dx=1024,dz=1024] run function pandamium:misc/spawn_restriction
+execute in minecraft:the_end as @a[gamemode=spectator,x=0] unless score @s staff_perms matches 2.. run tp @s 100.5 49.0 0.5 90 0
+execute in minecraft:the_end as @a[gamemode=spectator,x=0] unless score @s staff_perms matches 2.. run gamemode survival @s
+
 execute as @a run function pandamium:check_triggers
 execute as @a[scores={inventory=..-1,staff_perms=1..},limit=1] run function pandamium:triggers/inventory_shulkers
 execute as @a[scores={enderchest=..-1,staff_perms=1..},limit=1] run function pandamium:triggers/enderchest_shulkers
-
-execute as @a[gamemode=spectator] unless score @s staff_perms matches 2.. unless entity @s[x=-512,z=-512,dx=1024,dz=1024] run function pandamium:misc/spawn_restriction
-execute as @a[gamemode=spectator] unless score @s staff_perms matches 2.. if entity @s[nbt={Dimension:"minecraft:the_end"}] run gamemode survival @s
 
 execute as @a[x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] run function pandamium:misc/spawn_effects
 

--- a/pandamium_datapack/data/pandamium/functions/tpa/accept_request.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/accept_request.mcfunction
@@ -7,6 +7,7 @@ execute if score <can_accept> variable matches 1 run tellraw @p[tag=running_trig
 execute if score <can_accept> variable matches 1 run tellraw @s [{"text":"","color":"green"},{"text":"[TPA]","color":"blue"}," ",{"selector":"@p[tag=running_trigger]"}," ",{"text":"accepted","color":"aqua"}," your TPA request!"]
 
 execute if score <can_accept> variable matches 1 run tp @s @p[tag=running_trigger]
+execute if score <can_accept> variable matches 1 if entity @s[gamemode=spectator] unless entity @s[x=-512,z=-512,dx=1024,dz=1024] unless score @s staff_perms matches 2.. run gamemode survival
 execute if score <can_accept> variable matches 1 run experience add @s 0
 
 execute if score <can_accept> variable matches 1 run scoreboard players reset @p[tag=running_trigger] tpa_request


### PR DESCRIPTION
If helpers tpa out of spawn, they are switched to survival mode
If helpers tp to a home out of spawn, they are switched to survival mode

Changed the order of the spawn restriction to prevent helper force tp
Changed check for player in the_end to prevent nbt check
When switching to survival mode in the end, helper is teleported to the end platform