### PR TITLE
Moved jail items to staff world

### DIFF
--- a/pandamium_datapack/data/minecraft/loot_tables/blocks/shulker_box.json
+++ b/pandamium_datapack/data/minecraft/loot_tables/blocks/shulker_box.json
@@ -1,0 +1,68 @@
+{
+    "type": "block",
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "alternatives",
+                    "children": [
+                        {
+                            "type": "dynamic",
+                            "name": "contents",
+                            "conditions": [
+                                {
+                                    "condition": "match_tool",
+                                    "predicate": {
+                                        "item": "air",
+                                        "nbt": "{drop_contents:1b}"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "item",
+                            "name": "shulker_box",
+                            "functions": [
+                                {
+                                    "function": "copy_name",
+                                    "source": "block_entity"
+                                },
+                                {
+                                    "function": "copy_nbt",
+                                    "source": "block_entity",
+                                    "ops": [
+                                        {
+                                            "source": "Lock",
+                                            "target": "BlockEntityTag.Lock",
+                                            "op": "replace"
+                                        },
+                                        {
+                                            "source": "LootTable",
+                                            "target": "BlockEntityTag.LootTable",
+                                            "op": "replace"
+                                        },
+                                        {
+                                            "source": "LootTableSeed",
+                                            "target": "BlockEntityTag.LootTableSeed",
+                                            "op": "replace"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "function": "set_contents",
+                                    "entries": [
+                                        {
+                                            "type": "dynamic",
+                                            "name": "contents"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -34,7 +34,9 @@ execute in the_nether as @e[type=ghast,x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024]
 
 execute as @a[scores={tpa_request=1..}] run function pandamium:tpa/request_timer
 
-execute as @a[scores={jailed=1..}] unless data entity @s {Dimension:"minecraft:overworld"} run tp @s 3 57 0
+scoreboard players set @a in_overworld 0
+scoreboard players set @a[x=0] in_overworld 1
+tp @a[scores={jailed=1..,in_overworld=0}] 3 57 0
 execute as @a[scores={jailed=1..}] unless entity @s[x=-6,y=56,z=-6,dx=20,dy=5,dz=12] run tp @s 3 57 0
 execute as @a[x=-6,y=57,z=-6,dx=20,dy=4,dz=12] unless score @s jailed matches 1.. unless score @s staff_perms matches 1.. run scoreboard players set @s spawn 1
 execute as @e[type=item,x=-6,y=57,z=-6,dx=20,dy=4,dz=12] in pandamium:staff_world run function pandamium:misc/jail_items/as_item

--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -34,10 +34,10 @@ execute in the_nether as @e[type=ghast,x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024]
 
 execute as @a[scores={tpa_request=1..}] run function pandamium:tpa/request_timer
 
-execute as @a if score @s jailed matches 1.. unless data entity @s {Dimension:"minecraft:overworld"} run tp @s 3 57 0
-execute as @a if score @s jailed matches 1.. unless entity @s[x=-6,y=56,z=-6,dx=20,dy=5,dz=12] run tp @s 3 57 0
+execute as @a[scores={jailed=1..}] unless data entity @s {Dimension:"minecraft:overworld"} run tp @s 3 57 0
+execute as @a[scores={jailed=1..}] unless entity @s[x=-6,y=56,z=-6,dx=20,dy=5,dz=12] run tp @s 3 57 0
 execute as @a[x=-6,y=57,z=-6,dx=20,dy=4,dz=12] unless score @s jailed matches 1.. unless score @s staff_perms matches 1.. run scoreboard players set @s spawn 1
-execute as @e[type=item,x=-6,y=57,z=-6,dx=20,dy=4,dz=12] run tp 2.5 53 2.5
+execute as @e[type=item,x=-6,y=57,z=-6,dx=20,dy=4,dz=12] in pandamium:staff_world run function pandamium:misc/jail_items/as_item
 
 execute as @a run scoreboard players operation @s playtime_hours = @s playtime_ticks
 scoreboard players operation @a playtime_hours /= <ticks_per_hour> variable

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/as_item.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/as_item.mcfunction
@@ -1,0 +1,30 @@
+#RUN IN pandamium:staff_world
+data modify storage pandamium:jail_items NBT set from entity @s
+data modify storage pandamium:jail_items Thrower set from storage pandamium:jail_items NBT.Thrower
+data modify storage pandamium:jail_items Item set from storage pandamium:jail_items NBT.Item
+
+scoreboard players operation <hour+1> variable = <hour> variable
+scoreboard players add <hour+1> variable 1
+execute run setblock 7 64 -6 air
+setblock 7 64 -6 oak_sign{Text1:'[{"score":{"name":"<day>","objective":"variable"},"color":"gray","italic":false},"/",{"score":{"name":"<month>","objective":"variable"}},"/",{"score":{"name":"<year>","objective":"variable"}}," at ≈ ",{"score":{"name":"<hour>","objective":"variable"}},":00-",{"score":{"name":"<hour+1>","objective":"variable"}},":00 UTC"]',Text2:'{"text":"Unknown Thrower","color":"gray","italic":false}'}
+
+execute unless block 7 64 2 chest run setblock 7 64 2 chest[facing=west,type=right]
+execute unless block 7 64 3 chest run setblock 7 64 3 chest[facing=west,type=left]
+summon armor_stand 7 64 2 {Tags:["jail_items.chest"],NoGravity:1b,Invisible:1b,Marker:1b}
+scoreboard players set <chest_num> variable 0
+execute as @e[x=0,type=armor_stand,tag=jail_items.chest] run function pandamium:misc/jail_items/find_next_free_chest
+
+scoreboard players set <player_exists> variable 0
+execute in overworld as @a[x=0,scores={jailed=1..}] run function pandamium:misc/jail_items/find_thrower
+execute if score <player_exists> variable matches 0 run tellraw @a[scores={staff_perms=1..}] [{"text":"","color":"gray"},{"text":"[Info]","color":"dark_gray"}," A player threw an item in jail! It was put into ",[{"text":"Jail Items Chest ","bold":true},{"score":{"name":"<chest_num>","objective":"variable"}}],"."]
+
+data modify storage pandamium:jail_items Item.tag.jail_item set value 1b
+execute unless data storage pandamium:jail_items Item.tag.display run data modify storage pandamium:jail_items Item.tag.jail_item set value 2b
+data modify storage pandamium:jail_items Item.tag.display.Lore set value []
+data modify storage pandamium:jail_items Item.tag.display.Lore append from block 7 64 -6 Text1
+data modify storage pandamium:jail_items Item.tag.display.Lore append from block 7 64 -6 Text2
+
+execute at @e[x=0,type=armor_stand,tag=jail_items.chest] run function pandamium:misc/jail_items/insert_item
+
+kill @e[x=0,type=armor_stand,tag=jail_items.chest]
+kill @s

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/find_next_free_chest.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/find_next_free_chest.mcfunction
@@ -1,0 +1,11 @@
+execute if entity @s run scoreboard players add <chest_num> variable 1
+
+execute at @s store result score <right_slots_filled> variable run data get block ~ ~ ~ Items
+execute at @s store result score <left_slots_filled> variable run data get block ~ ~ ~1 Items
+
+execute if score <right_slots_filled> variable matches 27 if score <left_slots_filled> variable matches 27 at @s run tp @s ~ ~1 ~
+execute if score <right_slots_filled> variable matches 27 unless score <left_slots_filled> variable matches 27 at @s run tp @s ~ ~ ~1
+
+execute if score <right_slots_filled> variable matches 27 if score <left_slots_filled> variable matches 27 at @s unless block ~ ~ ~ chest run setblock ~ ~ ~ chest[facing=west,type=right]
+execute if score <right_slots_filled> variable matches 27 if score <left_slots_filled> variable matches 27 at @s unless block ~ ~ ~1 chest run setblock ~ ~ ~1 chest[facing=west,type=left]
+execute if score <right_slots_filled> variable matches 27 if score <left_slots_filled> variable matches 27 at @s run function pandamium:misc/jail_items/find_next_free_chest

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/find_thrower.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/find_thrower.mcfunction
@@ -1,0 +1,9 @@
+
+data modify storage pandamium:jail_items UUID set from storage pandamium:jail_items Thrower
+execute store success score <uuid_matches> variable run data modify storage pandamium:jail_items UUID set from entity @s UUID
+
+execute if score <uuid_matches> variable matches 0 run tag @s add thrower
+execute if score <uuid_matches> variable matches 0 in pandamium:staff_world run data merge block 7 64 -6 {Text2:'[{"text":"Dropped by ","color":"gray","italic":false},{"selector":"@p[tag=thrower]","color":"gray"}]'}
+execute if score <uuid_matches> variable matches 0 run tellraw @a[scores={staff_perms=1..}] [{"text":"","color":"gray"},{"text":"[Info]","color":"dark_gray"}," ",{"selector":"@p[tag=thrower]"}," threw an item in jail! It was put into ",[{"text":"Jail Items Chest ","bold":true},{"score":{"name":"<chest_num>","objective":"variable"}}],"."]
+execute if score <uuid_matches> variable matches 0 run tag @s remove thrower
+execute if score <uuid_matches> variable matches 0 run scoreboard players set <player_exists> variable 1

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/insert_item.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/insert_item.mcfunction
@@ -1,0 +1,5 @@
+loot insert ~ ~ ~ loot pandamium:placeholder
+#barrier{placeholder:1b}
+
+data modify storage pandamium:jail_items Item.Slot set from block ~ ~ ~ Items[{tag:{placeholder:1b}}].Slot
+data modify block ~ ~ ~ Items[{tag:{placeholder:1b}}] set from storage pandamium:jail_items Item

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/remove_lore.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/remove_lore.mcfunction
@@ -1,0 +1,8 @@
+item block 7 64 -7 container.0 copy entity @s weapon.mainhand
+
+execute if data block 7 64 -7 Items[{Slot:0b}].tag.Lore run tellraw @s [{"text":"[Info]","color":"dark_green"},{"text":" Removed all lore from this item!","color":"green"}]
+
+data remove block 7 64 -7 Items[0].tag.display.Lore
+execute store result score <check_display> variable run data get block 7 64 -7 Items[0].tag.display
+execute if score <check_display> variable matches 0 run data remove block 7 64 -7 Items[0].tag.display
+item entity @s weapon.mainhand copy block 7 64 -7 container.0

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/remove_lore.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/remove_lore.mcfunction
@@ -1,8 +1,0 @@
-item block 7 64 -7 container.0 copy entity @s weapon.mainhand
-
-execute if data block 7 64 -7 Items[{Slot:0b}].tag.Lore run tellraw @s [{"text":"[Info]","color":"dark_green"},{"text":" Removed all lore from this item!","color":"green"}]
-
-data remove block 7 64 -7 Items[0].tag.display.Lore
-execute store result score <check_display> variable run data get block 7 64 -7 Items[0].tag.display
-execute if score <check_display> variable matches 0 run data remove block 7 64 -7 Items[0].tag.display
-item entity @s weapon.mainhand copy block 7 64 -7 container.0

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/remove_lore_from_inventory.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/remove_lore_from_inventory.mcfunction
@@ -1,0 +1,29 @@
+setblock 7 64 -7 shulker_box
+
+execute store result score <jail_items_in_inventory> variable if data entity @s Inventory[].tag.jail_item
+
+data modify block 7 64 -7 Items set from entity @s Inventory
+data remove block 7 64 -7 Items[{tag:{jail_item:1b}}].tag.display.Lore
+data remove block 7 64 -7 Items[{tag:{jail_item:2b}}].tag.display
+data remove block 7 64 -7 Items[].tag.jail_item
+loot replace entity @s hotbar.0 mine 7 64 -7 air{drop_contents:1b}
+
+data remove block 7 64 -7 Items[]
+
+item block 7 64 -7 container.0 copy entity @s container.27
+item block 7 64 -7 container.1 copy entity @s container.28
+item block 7 64 -7 container.2 copy entity @s container.29
+item block 7 64 -7 container.3 copy entity @s container.30
+item block 7 64 -7 container.4 copy entity @s container.31
+item block 7 64 -7 container.5 copy entity @s container.32
+item block 7 64 -7 container.6 copy entity @s container.33
+item block 7 64 -7 container.7 copy entity @s container.34
+item block 7 64 -7 container.8 copy entity @s container.35
+data remove block 7 64 -7 Items[{tag:{jail_item:1b}}].tag.display.Lore
+data remove block 7 64 -7 Items[{tag:{jail_item:2b}}].tag.display
+data remove block 7 64 -7 Items[].tag.jail_item
+loot replace entity @s container.27 mine 7 64 -7 air{drop_contents:1b}
+
+setblock 7 64 -7 chest
+
+tellraw @s [{"text":"[Info]","color":"gold"},[{"text":" Removed Lore from ","color":"yellow"},{"score":{"name":"<jail_items_in_inventory>","objective":"variable"},"color":"gold","bold":true}," jail item",{"text":"(s)","color":"gray","italic":true}," in your inventory!"]]

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -114,6 +114,7 @@ scoreboard objectives add tpa_request dummy
 scoreboard objectives add tpa_request_time dummy
 
 scoreboard objectives add in_nether_spawn dummy
+scoreboard objectives add in_overworld dummy
 
 scoreboard objectives add alive dummy
 


### PR DESCRIPTION
The `shulker_box` loot table does not affect anything to do with gameplay. It is used by the `remove_lore_from_inventory` function to put the edited items back into the player's inventory using the `loot` command.