### PR TITLE
Included donator area in can-tpa check

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/tpa/accept_request.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/accept_request.mcfunction
@@ -1,4 +1,8 @@
-execute as @p[tag=running_trigger] run function pandamium:tpa/check_can_accept
+tag @s add sender
+tag @p[tag=running_trigger] add receiver
+function pandamium:tpa/check_can_accept
+tag @s remove sender
+tag @p[tag=running_trigger] remove receiver
 
 execute if score <can_accept> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You cannot accept TPA requests currently! ",{"text":"[X]","color":"dark_red","bold":true,"clickEvent":{"action":"run_command","value":"/trigger tpa set -2"},"hoverEvent":{"action":"show_text","contents":[{"text":"Deny Request","color":"dark_red"}]}}]
 

--- a/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
@@ -1,5 +1,5 @@
-tag @s add checking_can_accept
-execute in pandamium:staff_world store success score <can_accept> variable unless entity @a[x=0,tag=checking_can_accept]
-tag @s remove checking_can_accept
+scoreboard players set <can_accept> 1
 
-execute if score @s jailed matches 1.. run scoreboard players set <can_accept> variable 0
+execute in pandamium:staff_world if entity @a[tag=receiver,x=0] unless entity @s[tag=sender,scores={staff_perms=1..}] run scoreboard players set <can_accept> 0
+execute if entity @a[tag=receiver,x=-131,y=16,z=-10,dx=60,dy=34,dz=35] unless entity @s[tag=sender,scores={gameplay_perms=5..}] run scoreboard players set <can_accept> 0
+execute if score @p[tag=receiver] jailed matches 1.. run scoreboard players set <can_accept> variable 0

--- a/pandamium_datapack/data/pandamium/functions/tpa/check_cooldown.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/check_cooldown.mcfunction
@@ -6,6 +6,12 @@ execute as @a if score @s tpa_request = @p[tag=running_trigger] id run scoreboar
 
 execute as @a if score @p[tag=running_trigger] tpa = @s id run function pandamium:tpa/check_can_accept
 
+tag @p[tag=running_trigger] add sender
+execute as @a if score @p[tag=running_trigger] tpa = @s id run tag @s add receiver
+function pandamium:tpa/check_can_accept
+tag @p[tag=running_trigger] remove sender
+tag @a remove receiver
+
 execute if score @p[tag=running_trigger] jailed matches 1.. run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You cannot use this trigger in jail!"]
 execute unless score @p[tag=running_trigger] jailed matches 1.. if score <has_sent_request> variable matches 1 as @a if score @p[tag=running_trigger] id = @s tpa_request run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," You have already sent a TPA request to ",{"selector":"@s","color":"red"},"! ",{"text":"[X]","bold":true,"color":"gray","clickEvent":{"action":"run_command","value":"/trigger tpa set -3"},"hoverEvent":{"action":"show_text","contents":[{"text":"Cancel Request","color":"gray"}]}}]
 execute unless score @p[tag=running_trigger] jailed matches 1.. if score <has_sent_request> variable matches 0 if score <player_exists> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text":"[TPA]","color":"dark_red"}," Could not find that player."]


### PR DESCRIPTION
Those in the donator area cannot accept TPA requests unless the sender is also a donator
Those in the staff world cannot accept TPA requests unless the sender is also a staff member