### PR TITLE
Changed selected player tag names for teleport functions

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/teleport/random/main.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/teleport/random/main.mcfunction
@@ -1,4 +1,4 @@
-tag @s add selected_player
+tag @s add teleport.random.selected_player
 execute in pandamium:staff_world run summon minecart 0. 0 0. {Tags:["teleport_marker"]}
 execute in pandamium:staff_world as @e[type=minecart,tag=teleport_marker,x=0,y=0,z=0,distance=0] in overworld run function pandamium:misc/teleport/random/teleport_marker
-tag @s remove selected_player
+tag @s remove teleport.random.selected_player

--- a/pandamium_datapack/data/pandamium/functions/misc/teleport/random/teleport_marker.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/teleport/random/teleport_marker.mcfunction
@@ -5,6 +5,6 @@ execute store result score <rtp_x> variable run data get entity @s Pos[0]
 execute store result score <rtp_y> variable run data get entity @s Pos[1]
 execute store result score <rtp_z> variable run data get entity @s Pos[2]
 
-execute positioned as @s as @a[tag=selected_player] rotated as @s run function pandamium:misc/teleport/main
+execute positioned as @s as @a[tag=teleport.random.selected_player] rotated as @s run function pandamium:misc/teleport/main
 
-tellraw @a[tag=selected_player] [{"text":"","color":"green"},{"text":"[Info]","color":"blue"}," You have been teleported to ",[{"score":{"name":"<rtp_x>","objective":"variable"},"color":"aqua"}," ",{"score":{"name":"<rtp_y>","objective":"variable"}}," ",{"score":{"name":"<rtp_z>","objective":"variable"}}],"!"]
+tellraw @a[tag=teleport.random.selected_player] [{"text":"","color":"green"},{"text":"[Info]","color":"blue"}," You have been teleported to ",[{"score":{"name":"<rtp_x>","objective":"variable"},"color":"aqua"}," ",{"score":{"name":"<rtp_y>","objective":"variable"}}," ",{"score":{"name":"<rtp_z>","objective":"variable"}}],"!"]

--- a/pandamium_datapack/data/pandamium/functions/misc/teleport/to_scores/main.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/teleport/to_scores/main.mcfunction
@@ -1,5 +1,5 @@
 #a minecart contains not much nbt data, so it should be efficient to modify its Pos
-tag @s add selected_player
+tag @s add teleport.to_scores.selected_player
 execute in pandamium:staff_world run summon minecart 0. 0 0. {Tags:["teleport_marker"]}
 execute in pandamium:staff_world as @e[type=minecart,tag=teleport_marker,x=0,y=0,z=0,distance=0] run function pandamium:misc/teleport/to_scores/select_dimension
-tag @s remove selected_player
+tag @s remove teleport.to_scores.selected_player

--- a/pandamium_datapack/data/pandamium/functions/misc/teleport/to_scores/teleport.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/teleport/to_scores/teleport.mcfunction
@@ -7,4 +7,4 @@ execute store result storage pandamium:teleport Pos[2] double 1 run scoreboard p
 data modify entity @s Pos set from storage pandamium:teleport Pos
 data remove storage pandamium:teleport Pos
 
-execute positioned as @s positioned ~0.5 ~ ~0.5 as @a[tag=selected_player] rotated as @s run function pandamium:misc/teleport/main
+execute positioned as @s positioned ~0.5 ~ ~0.5 as @a[tag=teleport.to_scores.selected_player] rotated as @s run function pandamium:misc/teleport/main


### PR DESCRIPTION
Changed `selected_player` tags in the teleport functions to `teleport.selected_player` so that they don't interfere with triggers' `selected_player` (was running into some issues)