### PR TITLE
Added moderator restart countdown

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/restart_countdown.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/restart_countdown.mcfunction
@@ -1,0 +1,9 @@
+execute if score <restart_countdown> variable matches 60 run tellraw @a {"text":"[Restart] The server will restart in 60 seconds!","color":"red"}
+execute if score <restart_countdown> variable matches 30 run tellraw @a {"text":"[Restart] The server will restart in 30 seconds!","color":"red"}
+execute if score <restart_countdown> variable matches 10 run tellraw @a {"text":"[Restart] The server will restart in 10 seconds!","color":"red"}
+execute if score <restart_countdown> variable matches 1..5 run tellraw @a [{"text":"[Restart] The server will restart in ","color":"red"},{"score":{"name":"<restart_countdown>","objective":"variable"}}," seconds!"]
+execute if score <restart_countdown> variable matches 0 run kick @a The server was restarted! It will be back in 1-2 minutes.
+execute if score <restart_countdown> variable matches 0 run stop
+
+execute if score <restart_countdown> variable matches 1.. run schedule function pandamium:misc/restart_countdown 1s
+scoreboard players remove <restart_countdown> variable 1

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -252,6 +252,8 @@ function pandamium:misc/sidebar
 scoreboard players set <auto_message> variable 0
 schedule function pandamium:misc/auto_messages 60s
 
+scoreboard players set <restart_countdown> variable -1
+
 scoreboard players set <auto_clear> variable 36000
 
 function pandamium:misc/clear_netherrack

--- a/pandamium_datapack/data/pandamium/functions/triggers/restart.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/restart.mcfunction
@@ -1,6 +1,17 @@
-execute if score @s restart matches 1.. run tellraw @s [{"text":"","color":"red"},{"text":"[Restart]","color":"dark_red"}," Are you sure you want to ",{"text":"restart the server","underlined":true},"? ",{"text":"[✔]","bold":true,"color":"dark_green","hoverEvent":{"action":"show_text","value":{"text":"Restart the Server","color":"dark_green"}},"clickEvent":{"action":"run_command","value":"/trigger restart set -1"}}]
-execute if score @s restart matches ..-1 run kick @a The server is being restarted! It will be back in 1-2 minutes.
-execute if score @s restart matches ..-1 run stop
+execute if score @s restart matches 1.. run tellraw @s [{"text":"","color":"red"},{"text":"[Restart]","color":"dark_red"}," Confirm Restart! ",{"text":"[✔]","bold":true,"color":"dark_green","hoverEvent":{"action":"show_text","value":{"text":"Restart the Server Now","color":"dark_green"}},"clickEvent":{"action":"run_command","value":"/trigger restart set -1"}}," ",{"text":"[⌛]","bold":true,"color":"blue","hoverEvent":{"action":"show_text","value":{"text":"Restart the Server in 30 Seconds","color":"blue"}},"clickEvent":{"action":"run_command","value":"/trigger restart set -2"}}]
+
+execute if score @s restart matches -1 run kick @a The server was restarted! It will be back in 1-2 minutes.
+execute if score @s restart matches -1 run stop
+
+execute if score @s restart matches -2 run tellraw @a[scores={staff_perms=2..}] [{"text":"[Restart] ","color":"red"},{"selector":"@s"}," has scheduled a server restart! ",{"text":"[X]","bold":true,"color":"dark_red","hoverEvent":{"action":"show_text","value":{"text":"Cancel Restart","color":"dark_red"}},"clickEvent":{"action":"run_command","value":"/trigger restart set -3"}}]
+execute if score @s restart matches -2 run execute as @a unless score @s staff_perms matches 2.. run tellraw @s [{"text":"[Restart] ","color":"red"},{"selector":"@s"}," has scheduled a server restart!"]
+execute if score @s restart matches -2 run scoreboard players set <restart_countdown> variable 30
+execute if score @s restart matches -2 run function pandamium:misc/restart_countdown
+
+execute if score @s restart matches -3 unless score <restart_countdown> variable matches 1.. run tellraw @s [{"text":"[Restart]","color":"dark_red"},{"text":" The server is not restarting!","color":"red"}]
+execute if score @s restart matches -3 if score <restart_countdown> variable matches 1.. run tellraw @a [{"text":"[Restart] ","color":"red"},{"selector":"@s"}," cancelled the server restart!"]
+execute if score @s restart matches -3 run scoreboard players set <restart_countdown> variable -1
+execute if score @s restart matches -3 run schedule clear pandamium:misc/restart_countdown
 
 scoreboard players reset @s restart
 scoreboard players enable @s restart


### PR DESCRIPTION
Moderators (+) can schedule a restart with a 30-second countdown
They can also cancel this restart countdown if needed