### PR TITLE
Updated spawn effects

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -27,16 +27,14 @@ execute as @a run function pandamium:check_triggers
 execute as @a[scores={inventory=..-1,staff_perms=1..},limit=1] run function pandamium:triggers/inventory_shulkers
 execute as @a[scores={enderchest=..-1,staff_perms=1..},limit=1] run function pandamium:triggers/enderchest_shulkers
 
-execute as @a[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/spawn_effects
-execute in the_nether as @a[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/spawn_effects
+function pandamium:misc/nether_spawn_prot
+function pandamium:misc/spawn_effects
 
 tp @e[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024,type=#pandamium:remove_at_spawn,tag=!spawn_protected] 0 -1000 0
 kill @e[type=boat,x=-128,y=-64,z=-128,dx=256,dy=384,dz=256,tag=!spawn_protected]
+execute in the_nether run tp @e[type=ghast,x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024,tag=!spawn_protected] 0 -1000 0
 
 execute as @a[x=-12,y=86,z=13,distance=..2,gamemode=!spectator] run function pandamium:misc/teleport/random/main
-
-function pandamium:misc/nether_spawn_prot
-execute in the_nether as @e[type=ghast,x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] run tp 0 -1000 0
 
 execute as @a[scores={tpa_request=1..}] run function pandamium:tpa/request_timer
 

--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -19,16 +19,16 @@ execute store result score <player_count> variable if entity @a
 execute as @a[scores={playtime_ticks=1..5}] run function pandamium:first_join
 execute as @a unless score @s leave_count matches 0 run function pandamium:on_join
 
-execute as @a[gamemode=spectator] unless score @s staff_perms matches 2.. unless entity @s[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/spawn_restriction
-execute in the_end as @a[gamemode=spectator,x=0] unless score @s staff_perms matches 2.. run tp @s 100.5 49.0 0.5 90 0
-execute in the_end as @a[gamemode=spectator,x=0] unless score @s staff_perms matches 2.. run gamemode survival
-
 execute as @a run function pandamium:check_triggers
 execute as @a[scores={inventory=..-1,staff_perms=1..},limit=1] run function pandamium:triggers/inventory_shulkers
 execute as @a[scores={enderchest=..-1,staff_perms=1..},limit=1] run function pandamium:triggers/enderchest_shulkers
 
 function pandamium:misc/nether_spawn_prot
 function pandamium:misc/spawn_effects
+
+execute as @a[gamemode=spectator,scores={in_spawn=0}] unless score @s staff_perms matches 2.. run function pandamium:misc/spawn_restriction
+execute in the_end as @a[gamemode=spectator,x=0] unless score @s staff_perms matches 2.. run tp @s 100.5 49.0 0.5 90 0
+execute in the_end as @a[gamemode=spectator,x=0] unless score @s staff_perms matches 2.. run gamemode survival
 
 tp @e[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024,type=#pandamium:remove_at_spawn,tag=!spawn_protected] 0 -1000 0
 kill @e[type=boat,x=-128,y=-64,z=-128,dx=256,dy=384,dz=256,tag=!spawn_protected]

--- a/pandamium_datapack/data/pandamium/functions/misc/nether_spawn_prot.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/nether_spawn_prot.mcfunction
@@ -1,5 +1,7 @@
 scoreboard players set @a in_nether_spawn 0
 execute in the_nether run scoreboard players set @a[x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] in_nether_spawn 1
 
+gamerule sendCommandFeedback false
 gamemode survival @a[gamemode=adventure,scores={in_nether_spawn=0}]
 gamemode adventure @a[gamemode=survival,scores={in_nether_spawn=1}]
+gamerule sendCommandFeedback true

--- a/pandamium_datapack/data/pandamium/functions/misc/spawn_effects.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/spawn_effects.mcfunction
@@ -1,4 +1,10 @@
-effect give @s resistance 1 4 true
-effect give @s saturation 6 0 true
-effect give @s weakness 1 5 true
-effect give @s conduit_power 1 0 true
+scoreboard players set @a in_spawn 0
+scoreboard players set @a[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] in_spawn 1
+execute in the_nether run scoreboard players set @a[x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] in_spawn 1
+
+effect give @a[scores={in_spawn=1}] resistance 1 4 true
+effect give @a[scores={in_spawn=1}] saturation 6 0 true
+execute as @a[scores={in_spawn=1}] run attribute @s generic.attack_damage base set -64
+effect give @a[scores={in_spawn=1}] conduit_power 1 0 true
+
+execute as @a[scores={in_spawn=0}] run attribute @s generic.attack_damage base set 1

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -114,6 +114,7 @@ scoreboard objectives add tpa_request dummy
 scoreboard objectives add tpa_request_time dummy
 
 scoreboard objectives add in_nether_spawn dummy
+scoreboard objectives add in_spawn dummy
 scoreboard objectives add in_overworld dummy
 scoreboard objectives add in_jail dummy
 


### PR DESCRIPTION
- Made melee PVP at spawn impossible (switched out `weakness` for negative base attack_damage)
- Fixed spawn restriction (should now only run if the player is outside of spawn), also runs after trigger check so should prevent helper force-tp properly, now
- Removed "Your gamemode has been updated" message from nether spawn prot