### PR TITLE
Fix for phantom spawning at wrong players

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/phantoms/loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/phantoms/loop.mcfunction
@@ -1,2 +1,2 @@
-execute if predicate pandamium:is_night as @a[x=0,scores={time_since_rest=72000..}] unless entity @s[gamemode=spectator,scores={disable_insomnia=1}] at @s if blocks ~ ~ ~ ~ 319 ~ ~ ~1 ~ masked positioned ~ ~28 ~ run function pandamium:misc/phantoms/spawn
+execute if predicate pandamium:is_night as @a[x=0,scores={time_since_rest=72000..},gamemode=!spectator] unless score @s disable_insomnia matches 1 at @s if blocks ~ ~ ~ ~ 319 ~ ~ ~1 ~ masked positioned ~ ~28 ~ run function pandamium:misc/phantoms/spawn
 schedule function pandamium:misc/phantoms/loop 2400t


### PR DESCRIPTION
phantoms were spawning for players with `disable_insomnia` set to true