### PR TITLE
1.17 Pre-release 2

### DIFF
--- a/pandamium_datapack/data/pandamium/loot_tables/loot_bag_contents.json
+++ b/pandamium_datapack/data/pandamium/loot_tables/loot_bag_contents.json
@@ -245,7 +245,7 @@
         {
           "type": "item",
           "weight": 8,
-          "name": "azalea_leaves_flowers",
+          "name": "flowering_azalea_leaves",
           "functions": [
             {
               "function": "set_count",


### PR DESCRIPTION
Changed `azalea_leaves_flowers` to `flowering_azalea_leaves` in `pandamium:loot_bag_contents` loot table