### PR TITLE
Separated teleportation triggers

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -1,5 +1,3 @@
-execute if score @s spawn matches 1.. run function pandamium:triggers/spawn
-execute if score @s spawn matches ..-1 run function pandamium:triggers/spawn
 execute if score @s respawn matches 1.. run function pandamium:triggers/respawn
 execute if score @s options matches 1.. run function pandamium:triggers/options
 execute if score @s options matches ..-1 run function pandamium:triggers/options
@@ -7,7 +5,6 @@ execute if score @s vote matches 1.. run function pandamium:triggers/vote
 execute if score @s vote_shop matches 1.. run function pandamium:triggers/vote_shop
 execute if score @s vote_shop matches ..-1 run function pandamium:triggers/vote_shop
 execute if score @s discord matches 1.. run function pandamium:triggers/discord
-execute if score @s home matches 1.. run function pandamium:triggers/home
 execute if score @s sethome matches 1.. run function pandamium:triggers/set_home
 execute if score @s sethome matches ..-1 run function pandamium:triggers/set_home
 execute if score @s delhome matches 1.. run function pandamium:triggers/delete_home
@@ -15,7 +12,6 @@ execute if score @s delhome matches ..-1 run function pandamium:triggers/delete_
 execute if score @s playtime matches 1.. run function pandamium:triggers/playtime
 execute if score @s staff_menu matches 1.. run function pandamium:triggers/staff_menu
 execute if score @s jail matches 1.. run function pandamium:triggers/jail
-execute if score @s tp_pre_jail matches 1.. run function pandamium:triggers/tp_pre_jail
 execute if score @s unjail matches 1.. run function pandamium:triggers/unjail
 execute if score @s kick matches 1.. run function pandamium:triggers/kick
 execute if score @s ban matches 1.. run function pandamium:triggers/ban
@@ -32,14 +28,9 @@ execute if score @s get_guidebook matches 1.. run function pandamium:triggers/ge
 execute if score @s particles matches 1.. run function pandamium:triggers/particles
 execute if score @s particles matches ..-1 run function pandamium:triggers/particles
 execute if score @s tpa matches 1.. run function pandamium:triggers/tpa
-execute if score @s tpa matches ..-1 run function pandamium:triggers/tpa_function
 execute if score @s homes matches 1.. run function pandamium:triggers/show_homes
-execute if score @s homes matches ..-1 run function pandamium:triggers/force_tp_homes
 execute if score @s donator_area matches 1.. run function pandamium:triggers/donator_area
 execute if score @s spawnpoint matches 1.. run function pandamium:triggers/show_spawnpoint
-execute if score @s spawnpoint matches ..-1 run function pandamium:triggers/force_tp_spawnpoint
-execute if score @s tp matches 1.. run function pandamium:triggers/tp
-execute if score @s tp matches ..-1 run function pandamium:triggers/tp
 execute if score @s leaderboards matches 1.. run function pandamium:triggers/leaderboards
 execute if score @s leaderboards matches ..-1 run function pandamium:triggers/leaderboards
 execute if score @s pose matches 1.. at @s run function pandamium:triggers/pose
@@ -50,8 +41,19 @@ execute if score @s take_binding matches 1.. run function pandamium:triggers/tak
 execute if score @s clear matches 1.. run function pandamium:triggers/clear
 execute if score @s clear matches ..-1 run function pandamium:triggers/clear
 execute if score @s hat matches 1.. run function pandamium:triggers/hat
-execute if score @s staff_world matches 1.. run function pandamium:triggers/staff_world
 execute if score @s item_font matches 1.. in pandamium:staff_world run function pandamium:triggers/item_font
 execute if score @s item_font matches ..-1 in pandamium:staff_world run function pandamium:triggers/item_font
 execute if score @s sign_font matches 1.. at @s run function pandamium:triggers/sign_font
 execute if score @s sign_font matches ..-1 at @s run function pandamium:triggers/sign_font
+
+#teleport triggers
+execute if score @s home matches 1.. run function pandamium:triggers/home
+execute if score @s spawn matches 1.. run function pandamium:triggers/spawn
+execute if score @s spawn matches ..-1 run function pandamium:triggers/spawn
+execute if score @s tp_pre_jail matches 1.. run function pandamium:triggers/tp_pre_jail
+execute if score @s tpa matches ..-1 run function pandamium:triggers/tpa_function
+execute if score @s homes matches ..-1 run function pandamium:triggers/force_tp_homes
+execute if score @s spawnpoint matches ..-1 run function pandamium:triggers/force_tp_spawnpoint
+execute if score @s tp matches 1.. run function pandamium:triggers/tp
+execute if score @s tp matches ..-1 run function pandamium:triggers/tp
+execute if score @s staff_world matches 1.. run function pandamium:triggers/staff_world


### PR DESCRIPTION
To prevent other triggers from being able to be run at spawn if triggered within the same block of 5 ticks. This can currently happen as the `in_spawn` score isn't updated every time someone teleports.
