### PR TITLE
Fixed switching jails not teleporting automatically

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -4,7 +4,7 @@ function pandamium:misc/update_dimension
 
 scoreboard players set @a in_jail 0
 scoreboard players set @a[x=-3,y=32,z=76,dx=6,dy=6,dz=9] in_jail 1
-scoreboard players set @a[x=9,y=32,z=65,dx=3,dy=5,dz=4] in_jail 1
+scoreboard players set @a[x=9,y=32,z=65,dx=3,dy=5,dz=4] in_jail 2
 
 # @a selects all players, @e[type=player] only alive ones
 scoreboard players set @a alive 0
@@ -37,9 +37,9 @@ execute as @a[x=-12,y=86,z=13,distance=..2,gamemode=!spectator] run function pan
 
 execute as @a[scores={tpa_request=1..}] run function pandamium:tpa/request_timer
 
-tp @a[scores={jailed=1,in_jail=0}] -1 32 80 90 0
-tp @a[scores={jailed=2,in_jail=0}] 11.0 32 67.5 0 0
-execute as @a[scores={in_jail=1}] unless score @s jailed matches 1.. unless score @s staff_perms matches 1.. run function pandamium:misc/teleport/spawn
+execute as @a[scores={jailed=1}] unless score @s in_jail matches 1 tp @s -1 32 80 90 0
+execute as @a[scores={jailed=2}] unless score @s in_jail matches 2 tp @s 11.0 32 67.5 0 0
+execute as @a[scores={in_jail=1..}] unless score @s jailed matches 1.. unless score @s staff_perms matches 1.. run function pandamium:misc/teleport/spawn
 execute as @e[type=item,x=-3,y=32,z=76,dx=6,dy=6,dz=9,tag=!jail_items.ignore] in pandamium:staff_world run function pandamium:misc/jail_items/as_item
 execute as @e[type=item,x=9,y=32,z=65,dx=3,dy=5,dz=4,tag=!jail_items.ignore] in pandamium:staff_world run function pandamium:misc/jail_items/as_item
 

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -2,6 +2,7 @@ execute unless score @s id matches 1.. run function pandamium:misc/assign_id
 function pandamium:misc/update_teams
 
 execute if score @s active_particles matches 1.. unless score @s gameplay_perms matches 6.. run scoreboard players set @s active_particles 0
+execute if score @s jailed matches 3.. run scoreboard players set @s jailed 1
 
 scoreboard players reset @s tpa_request
 scoreboard players reset @s selected_player


### PR DESCRIPTION
- if in the incorrect jail cell, the player should now get teleported to the right one
- on join, players with `jailed` score of 3 or more should now have it set to 1