### PR TITLE
Changed EntCap to MobCap

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/sidebar.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/sidebar.mcfunction
@@ -1,5 +1,5 @@
 scoreboard players operation Players: sidebar = <player_count> variable
-scoreboard players operation EntCap: sidebar = <mob_limit> variable
+scoreboard players operation MobCap: sidebar = <mob_limit> variable
 
 execute store result score Entities: sidebar if entity @e[type=!#pandamium:mob_limit_excluded]
 execute store result score Items: sidebar if entity @e[type=item]

--- a/pandamium_datapack/data/pandamium/functions/misc/sidebar.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/sidebar.mcfunction
@@ -1,7 +1,7 @@
 scoreboard players operation Players: sidebar = <player_count> variable
 scoreboard players operation MobCap: sidebar = <mob_limit> variable
 
-execute store result score Entities: sidebar if entity @e[type=!#pandamium:mob_limit_excluded]
+execute store result score Mobs: sidebar if entity @e[type=!#pandamium:mob_limit_excluded]
 execute store result score Items: sidebar if entity @e[type=item]
 
 schedule function pandamium:misc/sidebar 20t


### PR DESCRIPTION
Renamed `EntCap:` to `MobCap:` as it only really tracks mobs at this point, and it makes it more obvious what it's referring to
Also changed `Entites:` to `Mobs:`