### PR TITLE
Added staff perms lock

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
@@ -15,7 +15,7 @@ scoreboard players set @s[team=veteran] gameplay_perms 4
 execute unless entity @s[team=!elite,team=!helper] run scoreboard players set @s gameplay_perms 5
 execute unless entity @s[team=!donator,team=!elder+,team=!veteran+,team=!elite+,team=!vip,team=!helper+,team=!mod,team=!srmod,team=!admin,team=!owner] run scoreboard players set @s gameplay_perms 6
 
-scoreboard players reset @s staff_perms
+execute unless score @s lock_staff_perms matches 1 run scoreboard players reset @s staff_perms
 execute unless entity @s[team=!helper,team=!helper+] run scoreboard players set @s staff_perms 1
 scoreboard players set @s[team=mod] staff_perms 2
 scoreboard players set @s[team=srmod] staff_perms 3

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -4,6 +4,7 @@ execute unless score <next_id> variable matches 2.. run scoreboard players set <
 
 scoreboard objectives add gameplay_perms dummy
 scoreboard objectives add staff_perms dummy
+scoreboard objectives add lock_staff_perms dummy
 scoreboard objectives add jailed dummy
 scoreboard objectives add cheater dummy
 scoreboard objectives add pre_jail_pos_x dummy
@@ -177,8 +178,8 @@ scoreboard players reset * take_binding
 scoreboard players reset * spawnpoint
 scoreboard players reset * tp_pre_jail
 
+# Do not reset [staff_perms] or [lock_staff_perms]
 scoreboard players reset * gameplay_perms
-scoreboard players reset * staff_perms
 scoreboard players reset * leave_count
 scoreboard players reset * in_nether_spawn
 scoreboard players reset * in_dimension


### PR DESCRIPTION
Setting a staff member's `lock_staff_perms` score to 1 will prevent the datapack from resetting their staff perms  (allowing for alts to have staff perms without being in a staff team)