### PR TITLE
Staff QOL Changes

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/first_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/first_join.mcfunction
@@ -3,8 +3,10 @@ function pandamium:misc/give_guidebook
 
 playsound entity.experience_orb.pickup player @a[scores={staff_perms=1..}] ~ ~ ~ 1 2 1
 
-tellraw @a [{"text":"[Server] ","color":"dark_blue"},{"text":"Welcome to the server ","color":"dark_aqua"},{"selector":"@s"},{"text":"! Have fun!","color":"dark_aqua"}]
+scoreboard players add @a staff_perms 0
+tellraw @a[scores={staff_perms=0}] [{"text":"[Server] ","color":"dark_blue"},[{"text":"Welcome to the server, ","color":"dark_aqua"},{"selector":"@s"},"! Have fun!"]]
+tellraw @a[scores={staff_perms=1..}] [{"text":"[Server] ","color":"dark_blue","clickEvent":{"action":"run_command","value":"/trigger spawn set -1"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to Teleport to ","color":"yellow"},{"text":"Spawn","bold":true,"color":"gold"}]}},[{"text":"Welcome to the server, ","color":"dark_aqua"},{"selector":"@s","clickEvent":{"action":"run_command","value":"/trigger spawn set -1"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to Teleport to ","color":"yellow"},{"text":"Spawn","bold":true,"color":"gold"}]}},"! Have fun!"]]
 
-tellraw @s [{"text":"[Server] ","color":"dark_blue"},{"text":"Read the guidebook to get started and join the official ","color":"green"},{"text":"Discord","color":"aqua"},{"text":" server for the full rules and announcements about the server! Click ","color":"green"},{"text":"[here]","color":"aqua","clickEvent":{"action":"open_url","value":"http://discord.pandamium.eu"}},{"text":" to join!","color":"green"}]
+tellraw @s [{"text":"[Server] ","color":"dark_blue"},{"text":"Read the guidebook to get started and join the official ","color":"green"},{"text":"Discord","color":"aqua"},{"text":" server for the full rules and announcements about the server! Click ","color":"green"},{"text":"[Here]","color":"aqua","clickEvent":{"action":"open_url","value":"http://discord.pandamium.eu"}},{"text":" to join!","color":"green"}]
 
 tellraw @a[scores={staff_perms=1..}] [{"text":"","color":"gray"},{"text":"[Info] ","color":"dark_gray"},{"selector":"@s","color":"gray"},"'s id is ",{"score":{"objective":"id","name":"@s"},"bold":true},"!"]

--- a/pandamium_datapack/data/pandamium/functions/misc/jail_items/find_thrower.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/jail_items/find_thrower.mcfunction
@@ -4,6 +4,6 @@ execute store success score <uuid_matches> variable if score <uuid_does_not_matc
 
 execute if score <uuid_matches> variable matches 1 run tag @s add thrower
 execute if score <uuid_matches> variable matches 1 in pandamium:staff_world run data merge block 0 2 0 {Text2:'[{"text":"Dropped by ","color":"gray","italic":false},{"selector":"@p[tag=thrower]","color":"gray"}]'}
-execute if score <uuid_matches> variable matches 1 run tellraw @a[scores={staff_perms=1..}] [{"text":"[Info] ","color":"dark_gray"},{"selector":"@p[tag=thrower]","color":"gray"},{"text":" threw an item in jail!","color":"gray"}]
+execute if score <uuid_matches> variable matches 1 run tellraw @a[scores={staff_perms=1..}] [{"text":"[Info] ","color":"dark_gray","clickEvent":{"action":"run_command","value":"/trigger staff_world set 5"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Staff World","bold":true,"color":"gold"}]}},{"selector":"@p[tag=thrower]","color":"gray"},{"text":" threw an item in jail!","color":"gray"}]
 execute if score <uuid_matches> variable matches 1 run tag @s remove thrower
 execute if score <uuid_matches> variable matches 1 run scoreboard players set <player_exists> variable 1

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/loop.mcfunction
@@ -24,3 +24,6 @@ particle cloud -137.0 -31.75 11.0 0.75 -0.05 0.75 0.05 10
 particle portal 0 68 0 1 1 1 1 10
 execute as @a[x=0,y=68,z=0,dx=0,dy=0,dz=0,gamemode=!spectator] run function pandamium:misc/teleport/spawn
 execute as @a[x=0,y=32,z=0,dx=0,dy=0,dz=0,gamemode=!spectator] run function pandamium:misc/teleport/spawn
+
+#staff world teleport pad
+execute in pandamium:staff_world as @a[x=-6,y=63,z=8,dx=0,dy=3,dz=0] run function pandamium:misc/teleport/spawn

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -1,6 +1,6 @@
 execute unless score @s id matches 1.. run function pandamium:misc/assign_id
 function pandamium:misc/update_teams
-execute if score @s jailed matches 1.. run tellraw @a[scores={staff_perms=1..}] [{"text":"","color":"gray"},{"text":"[Info] ","color":"dark_gray"},{"selector":"@s","color":"gray"}," is still jailed."]
+execute if score @s jailed matches 1.. run tellraw @a[scores={staff_perms=1..}] [{"text":"[Info] ","color":"dark_gray","clickEvent":{"action":"run_command","value":"/trigger spawn set -3"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to Teleport to ","color":"yellow"},{"text":"Jail Area","bold":true,"color":"gold"}]}},{"selector":"@s","color":"gray","clickEvent":{"action":"run_command","value":"/trigger spawn set -3"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to Teleport to ","color":"yellow"},{"text":"Jail Area","bold":true,"color":"gold"}]}},{"text":" is still jailed.","color":"gray"}]
 
 execute if score @s active_particles matches 1.. unless score @s gameplay_perms matches 6.. run scoreboard players set @s active_particles 0
 execute if score @s jailed matches 3.. run scoreboard players set @s jailed 1

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -1,5 +1,6 @@
 execute unless score @s id matches 1.. run function pandamium:misc/assign_id
 function pandamium:misc/update_teams
+execute if score @s jailed matches 1.. run tellraw @a[scores={staff_perms=1..}] [{"text":"","color":"gray"},{"text":"[Info] ","color":"dark_gray"},{"selector":"@s","color":"gray"}," is still jailed."]
 
 execute if score @s active_particles matches 1.. unless score @s gameplay_perms matches 6.. run scoreboard players set @s active_particles 0
 execute if score @s jailed matches 3.. run scoreboard players set @s jailed 1

--- a/pandamium_datapack/data/pandamium/functions/triggers/discord.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/discord.mcfunction
@@ -6,13 +6,15 @@ execute if score @s discord matches 1 run tellraw @s [{"text":"[Discord] ","colo
 
 execute if score @s discord matches 1 if score @s staff_perms matches 1.. run function pandamium:misc/print_nearest_non_staff_player
 
-scoreboard players set <player_exists> variable 0
-execute if score @s discord matches 2.. if score @s staff_perms matches 1.. as @a if score @s id = @p[tag=running_trigger] discord run scoreboard players set <player_exists> variable 1
-execute if score @s discord matches 2.. if score @s staff_perms matches 1.. if score <player_exists> variable matches 0 run tellraw @s [{"text":"[Discord]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
+execute if score @s discord matches 2.. as @a if score @s id = @p[tag=running_trigger] discord run tag @s add selected_player
+execute store success score <player_exists> variable if entity @p[tag=selected_player]
+execute if score @s discord matches 2.. if score <player_exists> variable matches 0 run tellraw @s [{"text":"[Discord]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
 
-execute if score @s discord matches 2.. if score @s staff_perms matches 1.. as @a if score @s id = @p[tag=running_trigger] discord run tellraw @s [{"text":"","color":"green"},{"text":"[Discord] ","color":"blue"},[{"text":"","hoverEvent":{"action":"show_text","value":{"text":"Click here to join the Discord server!","color":"aqua"}},"clickEvent":{"action":"open_url","value":"http://discord.pandamium.eu/"}},{"selector":"@p[tag=running_trigger]"}," sent you the ",{"text":"Discord","color":"aqua"}," invite link! ",{"text":"Join us","color":"aqua"}," on ",{"text":"Discord","color":"aqua"}," at ",{"text":"discord.pandamium.eu","color":"aqua"}],"!"]
-execute if score @s discord matches 2.. if score @s staff_perms matches 1.. as @a if score @s id = @p[tag=running_trigger] discord run tellraw @p[tag=running_trigger] [{"text":"[Discord]","color":"gold"},[{"text":" Sent ","color":"yellow"},{"selector":"@s"}," the discord link!"]]
+execute if score @s discord matches 2.. if score <player_exists> variable matches 1 run tellraw @p[tag=selected_player] [{"text":"","color":"green"},{"text":"[Info] ","color":"blue"},[{"text":"","hoverEvent":{"action":"show_text","value":{"text":"Click here to join the Discord server!","color":"aqua"}},"clickEvent":{"action":"open_url","value":"http://discord.pandamium.eu/"}},{"selector":"@p[tag=running_trigger]"}," sent you the ",{"text":"Discord","color":"aqua"}," invite link! ",{"text":"Join us","color":"aqua"}," on ",{"text":"Discord","color":"aqua"}," at ",{"text":"discord.pandamium.eu","color":"aqua"}],"!"]
+execute if score @s discord matches 2.. if score <player_exists> variable matches 1 run tellraw @s [{"text":"[Discord]","color":"gold"},[{"text":" Sent ","color":"yellow"},{"selector":"@s"}," the discord link!"]]
+execute if score @s discord matches 2.. if score <player_exists> variable matches 1 run tellraw @a[scores={staff_perms=1..},tag=!running_trigger] [{"text":"","color":"gray"},{"text":"[Info] ","color":"dark_gray"},{"selector":"@s","color":"gray"}," sent ",{"selector":"@p[tag=selected_player]","color":"gray"}," a Discord invite."]
 
+tag @a remove selected_player
 tag @s remove running_trigger
 scoreboard players reset @s discord
 scoreboard players enable @s discord

--- a/pandamium_datapack/data/pandamium/functions/triggers/get_guidebook.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/get_guidebook.mcfunction
@@ -1,16 +1,19 @@
 tag @s add running_trigger
 
 execute unless score @s staff_perms matches 1.. run scoreboard players set @s get_guidebook -1
-execute if score @s get_guidebook matches -1 run tellraw @s [{"text":"[Info]","color":"dark_green"},{"text":" Gave you an updated guidebook!","color":"green"}]
+execute if score @s get_guidebook matches -1 run tellraw @s [{"text":"[Guidebook]","color":"dark_green"},{"text":" Gave you an updated guidebook!","color":"green"}]
 execute if score @s get_guidebook matches -1 run function pandamium:misc/give_guidebook
 
 execute if score @s get_guidebook matches 1 run function pandamium:misc/print_nearest_non_staff_player
 
 execute if score @s get_guidebook matches 2.. as @a if score @s id = @p[tag=running_trigger] get_guidebook run tag @s add selected_player
+execute store success score <player_exists> variable if entity @p[tag=selected_player]
+
 execute if score @s get_guidebook matches 2.. as @p[tag=selected_player] run function pandamium:misc/give_guidebook
 execute if score @s get_guidebook matches 2.. run tellraw @p[tag=selected_player] [{"text":"[Info] ","color":"blue"},{"selector":"@s"},{"text":" gave you a guidebook!","color":"green"}]
-execute if score @s get_guidebook matches 2.. if entity @p[tag=selected_player] run tellraw @s [{"text":"[Info]","color":"gold"},[{"text":" Gave ","color":"yellow"},{"selector":"@p[tag=selected_player]"}," a guidebook!"]]
-execute if score @s get_guidebook matches 2.. unless entity @p[tag=selected_player] run tellraw @s [{"text":"[Info]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
+execute if score @s get_guidebook matches 2.. if score <player_exists> variable matches 0 run tellraw @s [{"text":"[Guidebook]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
+execute if score @s get_guidebook matches 2.. if score <player_exists> variable matches 1 run tellraw @s [{"text":"[Guidebook]","color":"gold"},[{"text":" Gave ","color":"yellow"},{"selector":"@p[tag=selected_player]"}," a guidebook!"]]
+execute if score @s get_guidebook matches 2.. if score <player_exists> variable matches 1 run tellraw @a[scores={staff_perms=1..},tag=!running_trigger] [{"text":"","color":"gray"},{"text":"[Info] ","color":"dark_gray"},{"selector":"@s","color":"gray"}," gave ",{"selector":"@p[tag=selected_player]","color":"gray"}," a guidebook."]
 
 tag @a remove selected_player
 tag @s remove running_trigger

--- a/pandamium_datapack/data/pandamium/functions/triggers/staff_world.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/staff_world.mcfunction
@@ -1,12 +1,14 @@
+# run IN pandamium:staff_world
+
 spectate
 
-execute in pandamium:staff_world run tp @s 0 64 0 -90 0
+execute in pandamium:staff_world run tp @s 0 64 1 -90 0
 execute if score @s staff_world matches 2 in pandamium:staff_world run tp @s 5.5 64 -4.0 facing 7.0 63 -4.0
 execute if score @s staff_world matches 3 in pandamium:staff_world run tp @s 5.5 64 -1.5 facing 7.0 63 -1.5
 execute if score @s staff_world matches 4 in pandamium:staff_world run tp @s 5.5 64 0.5 facing 7.0 63 0.5
+execute if score @s staff_world matches 5 in pandamium:staff_world run tp @s 5.5 64 3.0 facing 7.0 63 2.5
 
 xp add @s 0
-
 scoreboard players set @s in_dimension 2
 
 scoreboard players reset @s staff_world

--- a/pandamium_datapack/data/pandamium/functions/triggers/take_binding.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/take_binding.mcfunction
@@ -19,13 +19,13 @@ execute as @a if score @p[tag=running_trigger] take_binding = @s id run scoreboa
 execute if score @s take_binding matches 1 run function pandamium:misc/print_nearest_non_staff_player
 
 #success
-execute if score @s take_binding matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_bound_items> variable matches 1 as @a if score @p[tag=running_trigger] take_binding = @s id run tellraw @p[tag=running_trigger] [{"text":"","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger staff_world set 4"},"hoverEvent":{"action":"show_text","value":{"text":"Teleport to Staff World","color":"yellow"}}},{"text":"[Info]","color":"gold"}," Took ",[{"selector":"@s"},"'s"]," ",{"text":"bound","bold":true}," items!"]
+execute if score @s take_binding matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_bound_items> variable matches 1 as @a if score @p[tag=running_trigger] take_binding = @s id run tellraw @p[tag=running_trigger] [{"text":"","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger staff_world set 4"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Staff World","bold":true,"color":"gold"}]}},{"text":"[Take]","color":"gold"}," Took ",[{"selector":"@s"},"'s"]," ",{"text":"bound","bold":true}," items!"]
 execute if score @s take_binding matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_bound_items> variable matches 1 as @a if score @p[tag=running_trigger] take_binding = @s id in pandamium:staff_world run function pandamium:take/move_binding
 
 #errors
-execute if score @s take_binding matches 2.. if score <player_exists> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"red"},{"text": "[Info]", "color":"dark_red"}," Could not find that player!"]
-execute if score @s take_binding matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 0 run tellraw @p[tag=running_trigger] [{"text": "[Info]", "color":"dark_red"},{"text":" Staff world chest still contains items!","color":"red"}]
-execute if score @s take_binding matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_bound_items> variable matches 0 run tellraw @p[tag=running_trigger] [{"text": "[Info]", "color":"dark_red"}," ",{"selector":"@s","color":"red"},{"text":" has no bound items to transfer!","color":"red"}]
+execute if score @s take_binding matches 2.. if score <player_exists> variable matches 0 run tellraw @s [{"text": "[Take]", "color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
+execute if score @s take_binding matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 0 run tellraw @s [{"text":"[Take]","color":"dark_red"},{"text":" Staff world chest still contains items!","color":"red"}]
+execute if score @s take_binding matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_bound_items> variable matches 0 run tellraw @s [{"text":"[Take] ","color":"dark_red"},{"selector":"@s","color":"red"},{"text":" has no bound items to transfer!","color":"red"}]
 
 tag @s remove running_trigger
 scoreboard players reset @s take_binding

--- a/pandamium_datapack/data/pandamium/functions/triggers/take_ec.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/take_ec.mcfunction
@@ -14,13 +14,13 @@ execute in pandamium:staff_world unless data block 7 64 -2 Items[0] run scoreboa
 execute if score @s take_ec matches 1 run function pandamium:misc/print_nearest_non_staff_player
 
 #success
-execute if score @s take_ec matches 2.. if score <player_exists> variable matches 1 if score <has_items> variable matches 1.. if score <empty_chest> variable matches 1 as @a if score @s id = @p[tag=running_trigger] take_ec run tellraw @p[tag=running_trigger] [{"text":"","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger staff_world set 3"},"hoverEvent":{"action":"show_text","value":{"text":"Teleport to Staff World","color":"yellow"}}},{"text":"[Info]","color":"gold"}," Took ",[{"selector":"@s"},"'s"]," ",{"text":"enderchest","bold":true}," items!"]
+execute if score @s take_ec matches 2.. if score <player_exists> variable matches 1 if score <has_items> variable matches 1.. if score <empty_chest> variable matches 1 as @a if score @s id = @p[tag=running_trigger] take_ec run tellraw @p[tag=running_trigger] [{"text":"","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger staff_world set 3"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Staff World","bold":true,"color":"gold"}]}},{"text":"[Take]","color":"gold"}," Took ",[{"selector":"@s"},"'s"]," ",{"text":"enderchest","bold":true}," items!"]
 execute if score @s take_ec matches 2.. if score <player_exists> variable matches 1 if score <has_items> variable matches 1.. if score <empty_chest> variable matches 1 as @a if score @s id = @p[tag=running_trigger] take_ec in pandamium:staff_world run function pandamium:take/move_ec
 
 #errors
-execute if score @s take_ec matches 2.. if score <player_exists> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"[Info]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
-execute if score @s take_ec matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"[Info]","color":"dark_red"},{"text":" Staff world chest still contains items!","color":"red"}]
-execute if score @s take_ec matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_items> variable matches 0 as @a if score @s id = @p[tag=running_trigger] take_ec run tellraw @p[tag=running_trigger] [{"text": "[Info]", "color":"dark_red"}," ",{"selector":"@s","color":"red"},{"text":" has no items in their enderchest!","color":"red"}]
+execute if score @s take_ec matches 2.. if score <player_exists> variable matches 0 run tellraw @s [{"text":"[Take]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
+execute if score @s take_ec matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 0 run tellraw @s [{"text":"[Info]","color":"dark_red"},{"text":" Staff world chest still contains items!","color":"red"}]
+execute if score @s take_ec matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_items> variable matches 0 run tellraw @s [{"text":"[Take] ","color":"dark_red"},{"selector":"@s","color":"red"},{"text":" has no items in their enderchest!","color":"red"}]
 
 tag @s remove running_trigger
 scoreboard players reset @s take_ec

--- a/pandamium_datapack/data/pandamium/functions/triggers/take_inv.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/take_inv.mcfunction
@@ -15,13 +15,13 @@ execute in pandamium:staff_world unless data block 7 64 -5 Items[0] unless data 
 execute if score @s take_inv matches 1 run function pandamium:misc/print_nearest_non_staff_player
 
 #success
-execute if score @s take_inv matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_items> variable matches 1 as @a if score @p[tag=running_trigger] take_inv = @s id run tellraw @p[tag=running_trigger] [{"text":"","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger staff_world set 2"},"hoverEvent":{"action":"show_text","value":{"text":"Teleport to Staff World","color":"yellow"}}},{"text":"[Info]","color":"gold"}," Took ",[{"selector":"@s"},"'s"]," ",{"text":"inventory","bold":true}," items!"]
+execute if score @s take_inv matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_items> variable matches 1 as @a if score @p[tag=running_trigger] take_inv = @s id run tellraw @p[tag=running_trigger] [{"text":"","color":"yellow","clickEvent":{"action":"run_command","value":"/trigger staff_world set 2"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Staff World","bold":true,"color":"gold"}]}},{"text":"[Take]","color":"gold"}," Took ",[{"selector":"@s"},"'s"]," ",{"text":"inventory","bold":true}," items!"]
 execute if score @s take_inv matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_items> variable matches 1 as @a if score @p[tag=running_trigger] take_inv = @s id in pandamium:staff_world run function pandamium:take/move_inv
 
 #errors
-execute if score @s take_inv matches 2.. if score <player_exists> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"[Info]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
-execute if score @s take_inv matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"[Info]","color":"dark_red"},{"text":" Staff world chest still contains items!","color":"red"}]
-execute if score @s take_inv matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_items> variable matches 0 run tellraw @p[tag=running_trigger] [{"text": "[Info]", "color":"dark_red"}," ",{"selector":"@s","color":"red"},{"text":" has no items in their inventory!","color":"red"}]
+execute if score @s take_inv matches 2.. if score <player_exists> variable matches 0 run tellraw @s [{"text":"[Take]","color":"dark_red"},{"text":" Could not find that player!","color":"red"}]
+execute if score @s take_inv matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 0 run tellraw @s [{"text":"[Take]","color":"dark_red"},{"text":" Staff world chest still contains items!","color":"red"}]
+execute if score @s take_inv matches 2.. if score <player_exists> variable matches 1 if score <empty_chest> variable matches 1 if score <has_items> variable matches 0 run tellraw @s [{"text":"[Take] ","color":"dark_red"},{"selector":"@s","color":"red"},{"text":" has no items in their inventory!","color":"red"}]
 
 tag @s remove running_trigger
 scoreboard players reset @s take_inv


### PR DESCRIPTION
- Made first join message a clickable message which teleports the staff member to spawn in spectator mode
- Made "player dropped item in jail" messages teleport staff member to jail items chest when clicked
- Added staff world teleport pad
- Made `get_guidebook` and `discord` staff triggers tell other staff when used (so that a player is not spammed with guidebooks or messages due to staff not knowing they were already given one)
- Made `staff_world` trigger teleport player to the centre of the platform
- `staff_world` trigger now must be run IN the staff world
- cleaned up a bunch of stuff and fixed font for `take_` trigger hover events
- Added "`player` is still jailed." staff message for when a player joins that is jailed (requested by Tec). Clicking this will teleport the staff member to the jail area