### PR TITLE
Added [container] trigger

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -50,6 +50,7 @@ execute if score @s sign_font matches ..-1 at @s run function pandamium:triggers
 execute if score @s world_info matches 1.. run function pandamium:triggers/world_info
 execute if score @s player_info matches 1.. run function pandamium:triggers/player_info
 execute if score @s player_info matches ..-1 run function pandamium:triggers/player_info
+execute if score @s container matches 1.. run function pandamium:triggers/container
 
 #teleport triggers
 execute if score @s home matches 1.. run function pandamium:triggers/home

--- a/pandamium_datapack/data/pandamium/functions/containers/brewing_stand.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/containers/brewing_stand.mcfunction
@@ -1,0 +1,4 @@
+data merge storage pandamium:containers {slot_prefix:'brewing_stand.'}
+data merge storage pandamium:containers {container:'brewing_stand'}
+
+function pandamium:containers/run/brewing_stand

--- a/pandamium_datapack/data/pandamium/functions/containers/furnace.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/containers/furnace.mcfunction
@@ -1,0 +1,4 @@
+data merge storage pandamium:containers {slot_prefix:'furnace.'}
+data merge storage pandamium:containers {container:'furnace'}
+
+function pandamium:containers/run/furnace

--- a/pandamium_datapack/data/pandamium/functions/containers/run/brewing_stand.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/containers/run/brewing_stand.mcfunction
@@ -1,0 +1,16 @@
+data modify storage pandamium:containers item set from storage pandamium:containers items[0]
+
+execute store result score <slot> variable run data get storage pandamium:containers item.Slot
+execute store result score <count> variable run data get storage pandamium:containers item.Count
+
+scoreboard players operation <display_slot> variable = <slot> variable
+execute if score <slot> variable matches 3..4 run scoreboard players reset <display_slot> variable
+
+execute if score <slot> variable matches 0..2 run data merge storage pandamium:containers {slot_prefix:'potion.'}
+execute if score <slot> variable matches 3 run data merge storage pandamium:containers {slot_prefix:'ingredient'}
+execute if score <slot> variable matches 4 run data merge storage pandamium:containers {slot_prefix:'fuel'}
+
+function pandamium:containers/run/print_item
+
+data remove storage pandamium:containers items[0]
+execute if data storage pandamium:containers items[0] run function pandamium:containers/run/brewing_stand

--- a/pandamium_datapack/data/pandamium/functions/containers/run/furnace.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/containers/run/furnace.mcfunction
@@ -1,0 +1,15 @@
+data modify storage pandamium:containers item set from storage pandamium:containers items[0]
+
+execute store result score <slot> variable run data get storage pandamium:containers item.Slot
+execute store result score <count> variable run data get storage pandamium:containers item.Count
+
+scoreboard players reset <display_slot> variable
+
+execute if score <slot> variable matches 0 run data merge storage pandamium:containers {slot_prefix:'input'}
+execute if score <slot> variable matches 1 run data merge storage pandamium:containers {slot_prefix:'fuel'}
+execute if score <slot> variable matches 2 run data merge storage pandamium:containers {slot_prefix:'result'}
+
+function pandamium:containers/run/print_item
+
+data remove storage pandamium:containers items[0]
+execute if data storage pandamium:containers items[0] run function pandamium:containers/run/furnace

--- a/pandamium_datapack/data/pandamium/functions/misc/raycast/create_bedrock_raycast.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/raycast/create_bedrock_raycast.mcfunction
@@ -4,5 +4,5 @@ summon marker ~ ~ ~ {Tags:["raycast.bedrock"]}
 execute at @s anchored eyes run tp @e[type=marker,tag=raycast.bedrock,limit=1] ^ ^ ^ ~ ~
 
 scoreboard players set <raycast_iters> variable 0
-scoreboard players set <in_bedrock> variable 0
+scoreboard players set <raycast_in_block> variable 0
 execute as @e[type=marker,tag=raycast.bedrock,limit=1] at @s run function pandamium:misc/raycast/iter_bedrock_raycast

--- a/pandamium_datapack/data/pandamium/functions/misc/raycast/create_container_raycast.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/raycast/create_container_raycast.mcfunction
@@ -1,0 +1,8 @@
+kill @e[type=marker,tag=raycast.container]
+
+summon marker ~ ~ ~ {Tags:["raycast.container"]}
+execute at @s anchored eyes run tp @e[type=marker,tag=raycast.container,limit=1] ^ ^ ^ ~ ~
+
+scoreboard players set <raycast_iters> variable 0
+scoreboard players set <raycast_in_block> variable 0
+execute as @e[type=marker,tag=raycast.container,limit=1] at @s run function pandamium:misc/raycast/iter_container_raycast

--- a/pandamium_datapack/data/pandamium/functions/misc/raycast/create_sign_raycast.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/raycast/create_sign_raycast.mcfunction
@@ -4,5 +4,5 @@ summon marker ~ ~ ~ {Tags:["raycast.sign"]}
 execute at @s anchored eyes run tp @e[type=marker,tag=raycast.sign,limit=1] ^ ^ ^ ~ ~
 
 scoreboard players set <raycast_iters> variable 0
-scoreboard players set <in_sign> variable 0
+scoreboard players set <raycast_in_block> variable 0
 execute as @e[type=marker,tag=raycast.sign,limit=1] at @s run function pandamium:misc/raycast/iter_sign_raycast

--- a/pandamium_datapack/data/pandamium/functions/misc/raycast/iter_bedrock_raycast.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/raycast/iter_bedrock_raycast.mcfunction
@@ -1,6 +1,6 @@
 scoreboard players add <raycast_iters> variable 1
 
-execute store success score <in_bedrock> variable if block ~ ~ ~ bedrock
+execute store success score <raycast_in_block> variable if block ~ ~ ~ bedrock
 
-execute if score <in_bedrock> variable matches 0 if score <raycast_iters> variable matches ..160 run tp ^ ^ ^0.03125
-execute if score <in_bedrock> variable matches 0 if score <raycast_iters> variable matches ..160 at @s run function pandamium:misc/raycast/iter_bedrock_raycast
+execute if score <raycast_in_block> variable matches 0 if score <raycast_iters> variable matches ..160 run tp ^ ^ ^0.03125
+execute if score <raycast_in_block> variable matches 0 if score <raycast_iters> variable matches ..160 at @s run function pandamium:misc/raycast/iter_bedrock_raycast

--- a/pandamium_datapack/data/pandamium/functions/misc/raycast/iter_container_raycast.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/raycast/iter_container_raycast.mcfunction
@@ -1,0 +1,6 @@
+scoreboard players add <raycast_iters> variable 1
+
+execute store success score <raycast_in_block> variable if block ~ ~ ~ #pandamium:containers
+
+execute if score <raycast_in_block> variable matches 0 if score <raycast_iters> variable matches ..160 run tp ^ ^ ^0.03125
+execute if score <raycast_in_block> variable matches 0 if score <raycast_iters> variable matches ..160 at @s run function pandamium:misc/raycast/iter_container_raycast

--- a/pandamium_datapack/data/pandamium/functions/misc/raycast/iter_sign_raycast.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/raycast/iter_sign_raycast.mcfunction
@@ -2,5 +2,5 @@ scoreboard players add <raycast_iters> variable 1
 
 execute if block ~ ~ ~ #signs run function pandamium:misc/raycast/check_inside_sign_hitbox
 
-execute if score <in_sign> variable matches 0 if score <raycast_iters> variable matches ..160 run tp ^ ^ ^0.03125
-execute if score <in_sign> variable matches 0 if score <raycast_iters> variable matches ..160 at @s run function pandamium:misc/raycast/iter_sign_raycast
+execute if score <raycast_in_block> variable matches 0 if score <raycast_iters> variable matches ..160 run tp ^ ^ ^0.03125
+execute if score <raycast_in_block> variable matches 0 if score <raycast_iters> variable matches ..160 at @s run function pandamium:misc/raycast/iter_sign_raycast

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -48,6 +48,7 @@ execute if score @s staff_perms matches 1.. run scoreboard players enable @s pla
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s ban
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s tp
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s tp_pre_jail
+execute if score @s staff_perms matches 2.. run scoreboard players enable @s container
 
 execute if score @s staff_perms matches 3.. run scoreboard players enable @s take_ec
 execute if score @s staff_perms matches 3.. run scoreboard players enable @s take_inv

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -44,11 +44,11 @@ execute if score @s staff_perms matches 1.. run scoreboard players enable @s sta
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s restart
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s item_clear
 execute if score @s staff_perms matches 1.. run scoreboard players enable @s player_info
+execute if score @s staff_perms matches 1.. run scoreboard players enable @s container
 
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s ban
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s tp
 execute if score @s staff_perms matches 2.. run scoreboard players enable @s tp_pre_jail
-execute if score @s staff_perms matches 2.. run scoreboard players enable @s container
 
 execute if score @s staff_perms matches 3.. run scoreboard players enable @s take_ec
 execute if score @s staff_perms matches 3.. run scoreboard players enable @s take_inv

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -60,6 +60,7 @@ scoreboard objectives add take_binding trigger
 scoreboard objectives add staff_world trigger
 scoreboard objectives add tp_pre_jail trigger
 scoreboard objectives add player_info trigger
+scoreboard objectives add container trigger
 
 scoreboard objectives add spawnpoint_x dummy
 scoreboard objectives add spawnpoint_y dummy
@@ -183,6 +184,7 @@ scoreboard players reset * take_binding
 scoreboard players reset * spawnpoint
 scoreboard players reset * tp_pre_jail
 scoreboard players reset * player_info
+scoreboard players reset * container
 
 # Do not reset [staff_perms] or [staff_alt]
 scoreboard players reset * gameplay_perms

--- a/pandamium_datapack/data/pandamium/functions/triggers/container.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/container.mcfunction
@@ -1,0 +1,22 @@
+function pandamium:misc/raycast/create_container_raycast
+execute store success score <can_run> variable if score <raycast_in_block> variable matches 1
+execute if score <can_run> variable matches 0 run tellraw @s [{"text":"[Inspect Block]","color":"dark_red"},{"text":" You are not looking at a container!","color":"red"}]
+
+execute if score <can_run> variable matches 1 run data modify storage pandamium:temp NBT set value {}
+execute if score <can_run> variable matches 1 at @e[type=marker,tag=raycast.container,limit=1] run data modify storage pandamium:temp NBT set from block ~ ~ ~
+execute if score <can_run> variable matches 1 run data modify storage pandamium:containers items set value []
+execute if score <can_run> variable matches 1 run data modify storage pandamium:containers items set from storage pandamium:temp NBT.Items
+
+execute if score <can_run> variable matches 1 store success score <has_items> variable if data storage pandamium:temp NBT.Items[0]
+
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 0 run tellraw @s [{"text":"[Containers] ","color":"dark_red"},[{"text":"The ","color":"red"},{"nbt":"NBT.id","storage":"pandamium:temp","bold":true}," at ",[{"nbt":"NBT.x","storage":"pandamium:temp","bold":true}," ",{"nbt":"NBT.y","storage":"pandamium:temp"}," ",{"nbt":"NBT.z","storage":"pandamium:temp"}]," has no items in it!"]]
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 1 run tellraw @s [{"text":"========","color":"yellow"},{"text":" Block Contents ","bold":true},"========",{"text":"\nTileEntity: ","bold":true,"color":"yellow"},{"nbt":"NBT.id","storage":"pandamium:temp","color":"green"},{"text":"\nLocation: ","bold":true,"color":"yellow"},[{"nbt":"NBT.x","storage":"pandamium:temp","bold":true,"color":"gold"}," ",{"nbt":"NBT.y","storage":"pandamium:temp"}," ",{"nbt":"NBT.z","storage":"pandamium:temp"}]]
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 1 if data storage pandamium:temp NBT{id:'minecraft:brewing_stand'} run function pandamium:containers/brewing_stand
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 1 if data storage pandamium:temp NBT{id:'minecraft:furnace'} run function pandamium:containers/furnace
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 1 if data storage pandamium:temp NBT{id:'minecraft:smoker'} run function pandamium:containers/furnace
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 1 if data storage pandamium:temp NBT{id:'minecraft:blast_furnace'} run function pandamium:containers/furnace
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 1 unless data storage pandamium:temp NBT{id:'minecraft:brewing_stand'} unless data storage pandamium:temp NBT{id:'minecraft:furnace'} unless data storage pandamium:temp NBT{id:'minecraft:smoker'} unless data storage pandamium:temp NBT{id:'minecraft:blast_furnace'} run function pandamium:containers/generic
+execute if score <can_run> variable matches 1 if score <has_items> variable matches 1 run tellraw @s {"text":"=================================","color":"yellow"}
+
+scoreboard players reset @s container
+scoreboard players enable @s container

--- a/pandamium_datapack/data/pandamium/functions/triggers/sign_font.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/sign_font.mcfunction
@@ -21,7 +21,7 @@ execute if score @s gameplay_perms matches 6.. if score @s sign_font matches -5 
 
 # Run
 execute if score <can_run> variable matches 1 run function pandamium:misc/raycast/create_sign_raycast
-execute if score <can_run> variable matches 1 run scoreboard players operation <can_run> variable = <in_sign> variable
+execute if score <can_run> variable matches 1 run scoreboard players operation <can_run> variable = <raycast_in_block> variable
 execute if score <can_run> variable matches 1 run data remove storage pandamium:sign SelectedLine
 execute if score <can_run> variable matches 1 run data modify storage pandamium:sign sign set value {}
 execute if score <can_run> variable matches 1 at @e[type=marker,tag=raycast.sign,limit=1] run data modify storage pandamium:sign sign set from block ~ ~ ~
@@ -73,7 +73,7 @@ execute if score <can_run> variable matches 1 if score @s sign_font matches -325
 execute if score @s sign_font matches ..-6 run scoreboard players set <displayed_error> variable 0
 execute if score @s sign_font matches ..-6 if score <can_run> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score @s sign_font matches ..-326 run tellraw @s [{"text":"[Sign Font]","color":"dark_red"},{"text":" This is not a valid option!","color":"red"}]
 execute if score @s sign_font matches ..-6 if score <can_run> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score @s in_spawn matches 1 run tellraw @s [{"text":"[Sign Font]","color":"dark_red"},{"text":" You cannot use this trigger at spawn!","color":"red"}]
-execute if score @s sign_font matches ..-6 if score <can_run> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score <in_sign> variable matches 0 run tellraw @s [{"text":"[Sign Font]","color":"dark_red"},{"text":" You are not looking at a sign!","color":"red"}]
+execute if score @s sign_font matches ..-6 if score <can_run> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score <raycast_in_block> variable matches 0 run tellraw @s [{"text":"[Sign Font]","color":"dark_red"},{"text":" You are not looking at a sign!","color":"red"}]
 
 kill @e[type=marker,tag=raycast.sign,limit=1]
 scoreboard players reset @s sign_font

--- a/pandamium_datapack/data/pandamium/functions/triggers/vote_shop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/vote_shop.mcfunction
@@ -53,9 +53,9 @@ execute if score <can_buy> variable matches 1 if score @s vote_shop matches -7 u
 execute if score <can_buy> variable matches 1 if score @s vote_shop matches -9 if score @s in_spawn matches 1 run scoreboard players set <can_buy> variable 0
 execute if score <can_buy> variable matches 1 if score @s vote_shop matches -12 at @s in the_nether unless entity @p[tag=running_trigger,y=120,dy=16] run scoreboard players set <can_buy> variable 0
 
-execute if score @s vote_shop matches -12 run scoreboard players set <in_bedrock> variable 0
+execute if score @s vote_shop matches -12 run scoreboard players set <raycast_in_block> variable 0
 execute if score <can_buy> variable matches 1 if score @s vote_shop matches -12 run function pandamium:misc/raycast/create_bedrock_raycast
-execute if score <can_buy> variable matches 1 if score @s vote_shop matches -12 unless score <in_bedrock> variable matches 1 run scoreboard players set <can_buy> variable 0
+execute if score <can_buy> variable matches 1 if score @s vote_shop matches -12 unless score <raycast_in_block> variable matches 1 run scoreboard players set <can_buy> variable 0
 execute if score @s vote_shop matches -12 run scoreboard players set <looking_into_spawn> variable 0
 execute if score <can_buy> variable matches 1 if score @s vote_shop matches -12 in the_nether if entity @e[type=marker,tag=raycast.bedrock,limit=1,x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] run scoreboard players set <looking_into_spawn> variable 1
 execute if score <looking_into_spawn> variable matches 1 run scoreboard players set <can_buy> variable 0
@@ -97,7 +97,7 @@ execute if score @s vote_shop matches ..-1 if score <can_buy> variable matches 0
 execute if score @s vote_shop matches ..-1 if score <can_buy> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score <gives_item> variable matches 1 if score <filled_inventory_slots> variable matches 36.. run tellraw @s [{"text":"","color":"red"},{"text":"[Vote Shop]","color":"dark_red"}," Your inventory is full!"]
 execute if score @s vote_shop matches ..-1 if score <can_buy> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score @s vote_shop matches -11 if score <can_give_mini_block> variable matches 0 run tellraw @s [{"text":"","color":"red"},{"text":"[Vote Shop]","color":"dark_red"}," Cannot mini-block-ify this item! Hold a block in your mainhand to get the mini-block form of it."]
 execute if score @s vote_shop matches ..-1 if score <can_buy> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score @s vote_shop matches -12 if score <looking_into_spawn> variable matches 1 run tellraw @s [{"text":"","color":"red"},{"text":"[Vote Shop]","color":"dark_red"}," You cannot buy this item at spawn!"]
-execute if score @s vote_shop matches ..-1 if score <can_buy> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score @s vote_shop matches -12 unless score <in_bedrock> variable matches 1 run tellraw @s [{"text":"","color":"red"},{"text":"[Vote Shop]","color":"dark_red"}," You must be looking at a piece of bedrock on the nether roof to buy this!"]
+execute if score @s vote_shop matches ..-1 if score <can_buy> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score @s vote_shop matches -12 unless score <raycast_in_block> variable matches 1 run tellraw @s [{"text":"","color":"red"},{"text":"[Vote Shop]","color":"dark_red"}," You must be looking at a piece of bedrock on the nether roof to buy this!"]
 
 tag @s remove running_trigger
 scoreboard players reset @s vote_shop

--- a/pandamium_datapack/data/pandamium/tags/blocks/containers.json
+++ b/pandamium_datapack/data/pandamium/tags/blocks/containers.json
@@ -1,0 +1,15 @@
+{
+	"values": [
+		"barrel",
+		"blast_furnace",
+		"brewing_stand",
+		"#campfires",
+		"chest",
+		"dispenser",
+		"dropper",
+		"furnace",
+		"#shulker_boxes",
+		"smoker",
+		"trapped_chest"
+	]
+}


### PR DESCRIPTION
- Added `/trigger container` for staff
- Lists the items in the container the player is looking at
- Can be used for looking in locked chests and containers that are encased in blocks
- Changed all raycast output variables from <in_`blockID`> to <raycast_in_block>