### PR TITLE
Updated loot tables to 1.17.1

### DIFF
--- a/pandamium_datapack/data/vanilla/loot_tables/entities/drowned.json
+++ b/pandamium_datapack/data/vanilla/loot_tables/entities/drowned.json
@@ -45,8 +45,8 @@
         },
         {
           "condition": "minecraft:random_chance_with_looting",
-          "chance": 0.05,
-          "looting_multiplier": 0.01
+          "chance": 0.11,
+          "looting_multiplier": 0.02
         }
       ]
     }


### PR DESCRIPTION
I had accidentally used the 1.17 entity loot tables