### PR TITLE
Added store_shulkerbox Trigger

### DIFF
--- a/pandamium_datapack/data/minecraft/tags/items/shulker_boxes.json
+++ b/pandamium_datapack/data/minecraft/tags/items/shulker_boxes.json
@@ -1,0 +1,21 @@
+{
+	"values": [
+		"shulker_box",
+		"black_shulker_box",
+		"blue_shulker_box",
+		"brown_shulker_box",
+		"cyan_shulker_box",
+		"gray_shulker_box",
+		"green_shulker_box",
+		"light_blue_shulker_box",
+		"light_gray_shulker_box",
+		"lime_shulker_box",
+		"magenta_shulker_box",
+		"orange_shulker_box",
+		"pink_shulker_box",
+		"purple_shulker_box",
+		"red_shulker_box",
+		"white_shulker_box",
+		"yellow_shulker_box"
+	]
+}

--- a/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -55,6 +55,9 @@ execute if score @s container matches 1.. run function pandamium:triggers/contai
 execute if score @s hide matches 1.. run function pandamium:triggers/hide
 execute if score @s auto_jails matches 1.. run function pandamium:triggers/auto_jails
 
+# Temporary
+execute if score @s store_shulkerbox matches 1.. run function pandamium:triggers/store_shulkerbox
+
 
 # Teleporting Triggers
 execute if score @s home matches 1.. run function pandamium:triggers/home

--- a/pandamium_datapack/data/pandamium/functions/misc/store_shulkerbox/do_insert.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/store_shulkerbox/do_insert.mcfunction
@@ -1,0 +1,14 @@
+# run IN pandamium:staff_world
+
+fill 0 0 0 0 1 0 shulker_box
+
+data modify block 0 0 0 Items set from storage pandamium:temp NBT.Inventory[{Slot:-106b}].tag.BlockEntityTag.Items
+
+item replace block 0 1 0 container.0 from entity @s weapon.mainhand
+loot insert 0 0 0 mine 0 1 0 air{drop_contents:1b}
+
+item replace block 0 1 0 container.0 from entity @s weapon.offhand
+data modify block 0 1 0 Items[0].tag.BlockEntityTag.Items set from block 0 0 0 Items
+
+loot replace entity @s weapon.offhand mine 0 1 0 air{drop_contents:1b}
+item replace entity @s weapon.mainhand with air

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -12,6 +12,9 @@ scoreboard players reset @s online_ticks
 scoreboard players reset @s tpa_request
 scoreboard players reset @s selected_player
 
+# Temporary
+scoreboard players enable @s store_shulkerbox
+
 scoreboard players enable @s spawn
 scoreboard players enable @s respawn
 scoreboard players enable @s options

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -16,6 +16,9 @@ scoreboard objectives add pre_jail_pos_d dummy
 scoreboard objectives add sidebar dummy {"text":"Pandamium","color":"blue","bold":true}
 scoreboard objectives setdisplay sidebar sidebar
 
+# Temporary
+scoreboard objectives add store_shulkerbox trigger
+
 scoreboard objectives add spawn trigger
 scoreboard objectives add respawn trigger
 scoreboard objectives add options trigger

--- a/pandamium_datapack/data/pandamium/functions/triggers/store_shulkerbox.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/store_shulkerbox.mcfunction
@@ -1,0 +1,22 @@
+data modify storage pandamium:temp NBT set from entity @s
+
+execute store result score <offhand_stored_items> variable if data storage pandamium:temp NBT.Inventory[{Slot:-106b}].tag.BlockEntityTag.Items[]
+
+scoreboard players set <mainhand_stored_shulker_boxes> variable 1
+execute unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:black_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:blue_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:brown_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:cyan_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:gray_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:green_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:light_blue_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:light_gray_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:lime_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:magenta_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:orange_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:pink_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:purple_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:red_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:white_shulker_box'}] unless data storage pandamium:temp NBT.SelectedItem.tag.BlockEntityTag.Items[{id:'minecraft:yellow_shulker_box'}] run scoreboard players set <mainhand_stored_shulker_boxes> variable 0
+
+scoreboard players set <can_run> variable 0
+execute if predicate pandamium:shulker_boxes_in_both_hands unless score <offhand_stored_items> variable matches 27 unless score <mainhand_stored_shulker_boxes> variable matches 1.. run scoreboard players set <can_run> variable 1
+
+# Display Error
+scoreboard players set <displayed_error> variable 0
+execute if score <can_run> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable unless predicate pandamium:shulker_boxes_in_both_hands run tellraw @s [{"text":"[Store Shulker Box]","color":"dark_red"},{"text":" You must be holding shulker boxes in both hands!","color":"red"}]
+execute if score <can_run> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score <offhand_stored_items> variable matches 27 run tellraw @s [{"text":"[Store Shulker Box]","color":"dark_red"},{"text":" The shulker box in your offhand is full!","color":"red"}]
+execute if score <can_run> variable matches 0 unless score <displayed_error> variable matches 1 store success score <displayed_error> variable if score <mainhand_stored_shulker_boxes> variable matches 1.. run tellraw @s [{"text":"[Store Shulker Box]","color":"dark_red"},{"text":" The shulker box in your main hand must not have shulker boxes inside it!","color":"red"}]
+
+# Do Insert
+execute if score <can_run> variable matches 1 in pandamium:staff_world run function pandamium:misc/store_shulkerbox/do_insert
+execute if score <can_run> variable matches 1 run tellraw @s [{"text":"[Store Shulker Box]","color":"dark_green"},[{"text":" Inserted the shulker box that was in your mainhand into the shulker box that is in your ","color":"green"},{"text":"offhand","color":"aqua"},"!"]]
+
+scoreboard players reset @s store_shulkerbox
+scoreboard players enable @s store_shulkerbox

--- a/pandamium_datapack/data/pandamium/predicates/shulker_boxes_in_both_hands.json
+++ b/pandamium_datapack/data/pandamium/predicates/shulker_boxes_in_both_hands.json
@@ -1,0 +1,24 @@
+[
+	{
+		"condition": "entity_properties",
+		"entity": "this",
+		"predicate": {
+			"equipment": {
+				"offhand": {
+					"tag": "shulker_boxes"
+				}
+			}
+		}
+	},
+	{
+		"condition": "entity_properties",
+		"entity": "this",
+		"predicate": {
+			"equipment": {
+				"mainhand": {
+					"tag": "shulker_boxes"
+				}
+			}
+		}
+	}
+]


### PR DESCRIPTION
- Holding shulker boxes in, both, your mainhand and offhand and running `/trigger store_shulkerbox` will insert your mainhand shulker box into the one in your offhand.
- The mainhand shulker box must not contain any shulker boxes