### PR TITLE
Changes to Attack Indicator

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_entity.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_entity.mcfunction
@@ -1,4 +1,4 @@
-# rounds Health to 2d.p., as `/data` always returns an integer
+# rounds Health to 2d.p., as [/data] always returns an integer
 execute store result storage pandamium:temp Health float 0.01 run data get entity @s Health 100
 
 execute store result score <max_health> variable run attribute @s generic.max_health get

--- a/pandamium_datapack/data/pandamium/functions/misc/attack_indicator/hurt_entity.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/attack_indicator/hurt_entity.mcfunction
@@ -1,5 +1,5 @@
 advancement revoke @s only pandamium:hurt_entity
 
 tag @s add player
-execute if score @s attack_indicator matches 1 at @s as @e[limit=1,sort=nearest,distance=..10,nbt={HurtTime:10s}] run function pandamium:misc/attack_indicator/as_entity
+execute if score @s attack_indicator matches 1 at @s as @e[limit=1,sort=nearest,distance=..32,tag=!player,nbt={HurtTime:10s}] run function pandamium:misc/attack_indicator/as_entity
 tag @s remove player


### PR DESCRIPTION
- No longers selects the players who inflicted the damage
- Increased search radius to 32 blocks (for projectile damage)