### PR TITLE
Fixed playersSleepingPercentage not updating properly

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/players_sleeping_percentage.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/players_sleeping_percentage.mcfunction
@@ -1,4 +1,5 @@
 execute if predicate pandamium:is_thundering run gamerule playersSleepingPercentage 50
 execute unless predicate pandamium:is_thundering run gamerule playersSleepingPercentage 33
 
-execute if score <player_count> variable matches 0..3 run gamerule playersSleepingPercentage 66
+execute in overworld store result score <players_who_can_sleep> variable if entity @a[x=0,gamemode=survival]
+execute if score <players_who_can_sleep> variable matches 0..3 run gamerule playersSleepingPercentage 66

--- a/pandamium_datapack/data/pandamium/functions/setup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/setup.mcfunction
@@ -2,7 +2,5 @@ gamerule keepInventory true
 gamerule doFireTick false
 gamerule doInsomnia false
 
-gamerule playersSleepingPercentage 33
-
 setworldspawn 0 85 0
 gamerule spawnRadius 0


### PR DESCRIPTION
- `playersSleepingPercentage` should now update according to the number of players online who can sleep, not all online players
- Removed `playersSleepingPercentage` from `pandamium:setup` function