### PR TITLE
Renamed monthly_playtime scoreboards

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -45,8 +45,8 @@ execute as @e[x=-39,y=144,z=-112,dx=5,dy=5,dz=7,type=item,tag=!jail_items.ignore
 
 execute as @a run scoreboard players operation @s playtime_hours = @s playtime_ticks
 scoreboard players operation @a playtime_hours /= <ticks_per_hour> variable
-execute as @a run scoreboard players operation @s monthly_playtime = @s monthly_pt_ticks
-scoreboard players operation @a monthly_playtime /= <ticks_per_hour> variable
+execute as @a run scoreboard players operation @s monthly_playtime_hours = @s monthly_playtime_ticks
+scoreboard players operation @a monthly_playtime_hours /= <ticks_per_hour> variable
 
 execute if score <sidebar_timer> global matches 5.. run scoreboard players remove <sidebar_timer> global 5
 execute if score <sidebar_timer> global matches ..0 unless score <sidebar> global matches 0 run scoreboard objectives setdisplay sidebar sidebar

--- a/pandamium_datapack/data/pandamium/functions/misc/afk_playtime.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/afk_playtime.mcfunction
@@ -8,7 +8,7 @@ execute unless score <afk_x> variable = @s afk_last_x run scoreboard players set
 execute unless score <afk_z> variable = @s afk_last_z run scoreboard players set @s afk_time 0
 
 execute if score @s afk_time matches 300.. run scoreboard players remove @s playtime_ticks 5
-execute if score @s afk_time matches 300.. run scoreboard players remove @s monthly_pt_ticks 5
+execute if score @s afk_time matches 300.. run scoreboard players remove @s monthly_playtime_ticks 5
 scoreboard players add @s afk_time 5
 
 scoreboard players operation @s afk_last_x = <afk_x> variable

--- a/pandamium_datapack/data/pandamium/functions/misc/print_playtime.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/print_playtime.mcfunction
@@ -9,16 +9,18 @@ scoreboard players operation <playtime_seconds> variable = @s playtime_ticks
 scoreboard players operation <playtime_seconds> variable /= <ticks_per_second> variable
 scoreboard players operation <playtime_seconds> variable %= <60> variable
 
-scoreboard players operation <monthly_playtime_hours> variable = @s monthly_pt_ticks
+
+scoreboard players operation <monthly_playtime_hours> variable = @s monthly_playtime_ticks
 scoreboard players operation <monthly_playtime_hours> variable /= <ticks_per_hour> variable
 
-scoreboard players operation <monthly_playtime_minutes> variable = @s monthly_pt_ticks
+scoreboard players operation <monthly_playtime_minutes> variable = @s monthly_playtime_ticks
 scoreboard players operation <monthly_playtime_minutes> variable /= <ticks_per_minute> variable
 scoreboard players operation <monthly_playtime_minutes> variable %= <60> variable
 
-scoreboard players operation <monthly_playtime_seconds> variable = @s monthly_pt_ticks
+scoreboard players operation <monthly_playtime_seconds> variable = @s monthly_playtime_ticks
 scoreboard players operation <monthly_playtime_seconds> variable /= <ticks_per_second> variable
 scoreboard players operation <monthly_playtime_seconds> variable %= <60> variable
+
 
 scoreboard players operation <online_playtime_hours> variable = @s online_ticks
 scoreboard players operation <online_playtime_hours> variable /= <ticks_per_hour> variable
@@ -30,6 +32,7 @@ scoreboard players operation <online_playtime_minutes> variable %= <60> variable
 scoreboard players operation <online_playtime_seconds> variable = @s online_ticks
 scoreboard players operation <online_playtime_seconds> variable /= <ticks_per_second> variable
 scoreboard players operation <online_playtime_seconds> variable %= <60> variable
+
 
 execute if score @p[tag=running_trigger] playtime matches 1 run tellraw @p[tag=running_trigger] [{"text":"======== ","color":"aqua"},{"text":"Playtime","bold":true}," ========",[{"text":"\nTotal Playtime: ","color":"green"},[{"text":"","color":"aqua"},{"score":{"name":"<playtime_hours>","objective":"variable"},"color":"aqua","bold":true}," hour",{"text":"(s)","color":"gray","italic":true}],", ",[{"text":"","color":"aqua"},{"score":{"name":"<playtime_minutes>","objective":"variable"},"color":"aqua","bold":true}," minute",{"text":"(s)","color":"gray","italic":true}]," and ",[{"text":"","color":"aqua"},{"score":{"name":"<playtime_seconds>","objective":"variable"},"color":"aqua","bold":true}," second",{"text":"(s)","color":"gray","italic":true}],"!"],[{"text":"\nMonthly Playtime: ","color":"green"},[{"text":"","color":"aqua"},{"score":{"name":"<monthly_playtime_hours>","objective":"variable"},"color":"aqua","bold":true}," hour",{"text":"(s)","color":"gray","italic":true}],", ",[{"text":"","color":"aqua"},{"score":{"name":"<monthly_playtime_minutes>","objective":"variable"},"color":"aqua","bold":true}," minute",{"text":"(s)","color":"gray","italic":true}]," and ",[{"text":"","color":"aqua"},{"score":{"name":"<monthly_playtime_seconds>","objective":"variable"},"color":"aqua","bold":true}," second",{"text":"(s)","color":"gray","italic":true}],"!"],[{"text":"\nOnline For: ","color":"green"},[{"text":"","color":"aqua"},{"score":{"name":"<online_playtime_hours>","objective":"variable"},"color":"aqua","bold":true}," hour",{"text":"(s)","color":"gray","italic":true}],", ",[{"text":"","color":"aqua"},{"score":{"name":"<online_playtime_minutes>","objective":"variable"},"color":"aqua","bold":true}," minute",{"text":"(s)","color":"gray","italic":true}]," and ",[{"text":"","color":"aqua"},{"score":{"name":"<online_playtime_seconds>","objective":"variable"},"color":"aqua","bold":true}," second",{"text":"(s)","color":"gray","italic":true}],"!"],"\n========================="]
 execute if score @p[tag=running_trigger] playtime matches 2.. run tellraw @p[tag=running_trigger] [{"text":"======== ","color":"yellow"},{"text":"Playtime","bold":true}," ========",{"text":"\nPlayer: ","bold":true},{"selector":"@s"},[{"text":"\nTotal Playtime: ","color":"gold"},[{"text":"","color":"yellow"},{"score":{"name":"<playtime_hours>","objective":"variable"},"color":"yellow","bold":true}," hour",{"text":"(s)","color":"gray","italic":true}],", ",[{"text":"","color":"yellow"},{"score":{"name":"<playtime_minutes>","objective":"variable"},"color":"yellow","bold":true}," minute",{"text":"(s)","color":"gray","italic":true}]," and ",[{"text":"","color":"yellow"},{"score":{"name":"<playtime_seconds>","objective":"variable"},"color":"yellow","bold":true}," second",{"text":"(s)","color":"gray","italic":true}],"!"],[{"text":"\nMonthly Playtime: ","color":"gold"},[{"text":"","color":"yellow"},{"score":{"name":"<monthly_playtime_hours>","objective":"variable"},"color":"yellow","bold":true}," hour",{"text":"(s)","color":"gray","italic":true}],", ",[{"text":"","color":"yellow"},{"score":{"name":"<monthly_playtime_minutes>","objective":"variable"},"color":"yellow","bold":true}," minute",{"text":"(s)","color":"gray","italic":true}]," and ",[{"text":"","color":"yellow"},{"score":{"name":"<monthly_playtime_seconds>","objective":"variable"},"color":"yellow","bold":true}," second",{"text":"(s)","color":"gray","italic":true}],"!"],[{"text":"\nOnline For: ","color":"gold"},[{"text":"","color":"yellow"},{"score":{"name":"<online_playtime_hours>","objective":"variable"},"color":"yellow","bold":true}," hour",{"text":"(s)","color":"gray","italic":true}],", ",[{"text":"","color":"yellow"},{"score":{"name":"<online_playtime_minutes>","objective":"variable"},"color":"yellow","bold":true}," minute",{"text":"(s)","color":"gray","italic":true}]," and ",[{"text":"","color":"yellow"},{"score":{"name":"<online_playtime_seconds>","objective":"variable"},"color":"yellow","bold":true}," second",{"text":"(s)","color":"gray","italic":true}],"!"],"\n========================="]

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -88,8 +88,8 @@ scoreboard objectives add vote_credits dummy
 
 scoreboard objectives add playtime_ticks custom:play_time
 scoreboard objectives add playtime_hours dummy {"text":"Top Playtime","color":"blue","bold":true}
-scoreboard objectives add monthly_pt_ticks custom:play_time
-scoreboard objectives add monthly_playtime dummy {"text":"Monthly Playtime","color":"blue","bold":true}
+scoreboard objectives add monthly_playtime_ticks custom:play_time
+scoreboard objectives add monthly_playtime_hours dummy {"text":"Monthly Playtime","color":"blue","bold":true}
 scoreboard objectives add online_ticks custom:play_time
 
 scoreboard objectives add home_1_x dummy

--- a/pandamium_datapack/data/pandamium/functions/triggers/leaderboards.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/leaderboards.mcfunction
@@ -11,7 +11,7 @@ execute if score @s gameplay_perms matches 6.. if score <value> variable matches
 
 execute if score <can_run> variable matches 1 if score <value> variable matches 1 run scoreboard objectives setdisplay sidebar playtime_hours
 execute if score <can_run> variable matches 1 if score <value> variable matches 2 run scoreboard objectives setdisplay sidebar votes
-execute if score <can_run> variable matches 1 if score <value> variable matches 3 run scoreboard objectives setdisplay sidebar monthly_playtime
+execute if score <can_run> variable matches 1 if score <value> variable matches 3 run scoreboard objectives setdisplay sidebar monthly_playtime_hours
 execute if score <can_run> variable matches 1 if score <value> variable matches 4 run scoreboard objectives setdisplay sidebar monthly_votes
 
 execute if score <can_run> variable matches 1 run scoreboard players operation <sidebar> global = <value> variable


### PR DESCRIPTION
- Renamed `monthly_pt_ticks` and `monthly_playtime` to `monthly_playtime_ticks` and `monthly_playtime_hours` respectively