### PR TITLE
Tweaked advancements

### DIFF
--- a/pandamium_datapack/data/pandamium/advancements/book_signed_via_mainhand.json
+++ b/pandamium_datapack/data/pandamium/advancements/book_signed_via_mainhand.json
@@ -10,7 +10,9 @@
 						"predicate": {
 							"equipment": {
 								"mainhand": {
-									"items": ["written_book"]
+									"items": [
+										"written_book"
+									]
 								}
 							}
 						}
@@ -32,7 +34,9 @@
 				],
 				"items": [
 					{
-						"items": ["written_book"]
+						"items": [
+							"written_book"
+						]
 					}
 				]
 			}

--- a/pandamium_datapack/data/pandamium/advancements/book_signed_via_offhand.json
+++ b/pandamium_datapack/data/pandamium/advancements/book_signed_via_offhand.json
@@ -10,7 +10,9 @@
 						"predicate": {
 							"equipment": {
 								"offhand": {
-									"items": ["written_book"]
+									"items": [
+										"written_book"
+									]
 								}
 							}
 						}
@@ -32,7 +34,9 @@
 				],
 				"items": [
 					{
-						"items": ["written_book"]
+						"items": [
+							"written_book"
+						]
 					}
 				]
 			}

--- a/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/pointed_dripstone.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/building_blocks/pointed_dripstone.json
@@ -1,5 +1,5 @@
 {
-	"parent": "minecraft:recipes/root",
+	"parent": "recipes/root",
 	"rewards": {
 		"recipes": [
 			"pandamium:pointed_dripstone_from_stalactite",

--- a/pandamium_datapack/data/pandamium/advancements/recipes/misc/copper_block_from_blasting_raw_copper_block.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/misc/copper_block_from_blasting_raw_copper_block.json
@@ -1,5 +1,5 @@
 {
-	"parent": "minecraft:recipes/root",
+	"parent": "recipes/root",
 	"rewards": {
 		"recipes": [
 			"pandamium:copper_block_from_blasting_raw_copper_block"

--- a/pandamium_datapack/data/pandamium/advancements/recipes/misc/gold_block_from_blasting_raw_gold_block.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/misc/gold_block_from_blasting_raw_gold_block.json
@@ -1,5 +1,5 @@
 {
-	"parent": "minecraft:recipes/root",
+	"parent": "recipes/root",
 	"rewards": {
 		"recipes": [
 			"pandamium:gold_block_from_blasting_raw_gold_block"

--- a/pandamium_datapack/data/pandamium/advancements/recipes/misc/iron_block_from_blasting_raw_iron_block.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/misc/iron_block_from_blasting_raw_iron_block.json
@@ -1,5 +1,5 @@
 {
-	"parent": "minecraft:recipes/root",
+	"parent": "recipes/root",
 	"rewards": {
 		"recipes": [
 			"pandamium:iron_block_from_blasting_raw_iron_block"

--- a/pandamium_datapack/data/pandamium/advancements/recipes/misc/leather_from_campfire_cooking.json
+++ b/pandamium_datapack/data/pandamium/advancements/recipes/misc/leather_from_campfire_cooking.json
@@ -1,5 +1,5 @@
 {
-	"parent": "minecraft:recipes/root",
+	"parent": "recipes/root",
 	"rewards": {
 		"recipes": [
 			"pandamium:leather_from_campfire_cooking"

--- a/pandamium_datapack/data/pandamium/advancements/spawnpoint_set.json
+++ b/pandamium_datapack/data/pandamium/advancements/spawnpoint_set.json
@@ -17,7 +17,9 @@
 				"location": {
 					"dimension": "the_nether",
 					"block": {
-						"blocks": ["respawn_anchor"]
+						"blocks": [
+							"respawn_anchor"
+						]
 					}
 				}
 			}


### PR DESCRIPTION
- Removed `minecraft:` prefix from `parent` advancement namespaces
- Reformatted `items` and `blocks` lists in advancements