### PR TITLE
Reset variable on startup

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -162,6 +162,8 @@ scoreboard objectives add alive dummy
 scoreboard objectives add temp_1 dummy
 
 
+scoreboard players reset * variable
+
 scoreboard players reset * spawn
 scoreboard players reset * respawn
 scoreboard players reset * vote


### PR DESCRIPTION
Now that all persistent variables have been moved to `global`, `variable` can be reset on startup