### PR TITLE
trigger spawn faces you towards RTP

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/teleport/spawn.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/teleport/spawn.mcfunction
@@ -1,4 +1,4 @@
 spectate
-execute in overworld run tp @s -7 138 3 145 0
+execute in overworld run tp @s -6.75 138 3.75 42 8
 xp add @s 0
 scoreboard players set @s in_dimension 0


### PR DESCRIPTION
- `/trigger spawn` should now teleport you slightly outside of the beacon beam, and facing the RTP pad