### PR TITLE
trigger parkour now teleports you to parkour start

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -71,5 +71,5 @@ execute if score @s tp matches ..-1 run function pandamium:triggers/tp
 execute if score @s auto_jails matches ..-1 run function pandamium:triggers/auto_jails
 execute if score @s switch_dimension matches ..-1 run function pandamium:triggers/switch_dimension
 execute if score @s staff_world matches 1.. run function pandamium:triggers/staff_world
-execute if score @s parkour matches 1.. run function pandamium:triggers/parkour/checkpoint
-execute if score @s parkour.end matches 1.. run function pandamium:triggers/parkour/end
+execute if score @s parkour matches 1.. run function pandamium:triggers/parkour
+execute if score @s parkour_end matches 1.. run function pandamium:triggers/parkour_end

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/end_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/end_parkour.mcfunction
@@ -1,5 +1,4 @@
-scoreboard players reset @s parkour
-scoreboard players reset @s parkour.end
+scoreboard players reset @s parkour_end
 
 scoreboard players reset @s parkour_checkpoint
 scoreboard players reset @s parkour_ticks

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/finish_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/finish_parkour.mcfunction
@@ -10,9 +10,9 @@ function pandamium:misc/map_specific/parkour/print_best_time
 
 #
 
-scoreboard players reset @s parkour
-scoreboard players reset @s parkour.end
+scoreboard players reset @s parkour_end
 scoreboard players reset @s parkour_checkpoint
 scoreboard players reset @s parkour_ticks
+
 function pandamium:misc/teleport/spawn
 execute at @s run playsound entity.player.levelup player @s ~ ~ ~ 1 2

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/start_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/start_parkour.mcfunction
@@ -1,7 +1,6 @@
 scoreboard players set @s parkour_checkpoint 0
 execute at @s run playsound entity.player.levelup player @s ~ ~ ~ 1 2
 
-scoreboard players enable @s parkour
-scoreboard players enable @s parkour.end
-tellraw @s [{"text":"[Parkour] You started the parkour!","color":"aqua"},[{"text":"\n• If you cheat, you will quit the parkour. ","color":"dark_aqua"},{"text":"Hover your mouse here to see what counts as cheating.","hoverEvent":{"action":"show_text","value":"• Using an elytra\n• Using an ender pearl\n• Consuming a chorus fruit\n• Having the Speed or Jump Boost effects\n• Teleporting using a trigger\n• Leaving spawn\n• Changing gamemode (staff-only)"}},"\n• If you get stuck, run ",{"text":"/trigger parkour","color":"aqua"}," to return to your last checkpoint.\n• To quit the parkour course, run ",{"text":"/trigger parkour.end","color":"aqua"}," ",{"text":"(stops tracking time and resets checkpoints)","color":"gray"}]]
+scoreboard players enable @s parkour_end
+tellraw @s [{"text":"[Parkour] You started the parkour!","color":"aqua"},[{"text":"\n• If you cheat, you will quit the parkour. ","color":"dark_aqua"},{"text":"Hover your mouse here to see what counts as cheating.","hoverEvent":{"action":"show_text","value":"• Using an elytra\n• Using an ender pearl\n• Consuming a chorus fruit\n• Having the Speed or Jump Boost effects\n• Teleporting using a trigger\n• Leaving spawn\n• Changing gamemode (staff-only)"}},"\n• If you get stuck, run ",{"text":"/trigger parkour","color":"aqua"}," to return to your last checkpoint.\n• To quit the parkour course, run ",{"text":"/trigger parkour_end","color":"aqua"}," ",{"text":"(stops tracking time and resets checkpoints)","color":"gray"}]]
 execute if score @s parkour_best_time matches 1.. run function pandamium:misc/map_specific/parkour/print_best_time

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -25,6 +25,7 @@ scoreboard players reset @s selected_player
 scoreboard players enable @s save_mob.spawn
 
 scoreboard players enable @s spawn
+scoreboard players enable @s parkour
 scoreboard players enable @s respawn
 scoreboard players enable @s options
 scoreboard players enable @s vote
@@ -38,6 +39,8 @@ scoreboard players enable @s tpa
 scoreboard players enable @s homes
 scoreboard players enable @s clear
 scoreboard players enable @s world_info
+
+execute if score @s parkour_checkpoint matches 0.. run scoreboard players enable @s parkour_end
 
 scoreboard players enable @s particles
 scoreboard players enable @s pose

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -42,7 +42,7 @@ scoreboard objectives add delhome trigger
 scoreboard objectives add tpa trigger
 
 scoreboard objectives add parkour trigger
-scoreboard objectives add parkour.end trigger
+scoreboard objectives add parkour_end trigger
 
 scoreboard objectives add particles trigger
 scoreboard objectives add pose trigger
@@ -181,6 +181,7 @@ scoreboard objectives add temp_1 dummy
 scoreboard players reset * variable
 
 scoreboard players reset * spawn
+scoreboard players reset * parkour
 scoreboard players reset * respawn
 scoreboard players reset * vote
 scoreboard players reset * vote_shop
@@ -192,6 +193,8 @@ scoreboard players reset * homes
 scoreboard players reset * tpa
 scoreboard players reset * playtime
 scoreboard players reset * world_info
+
+scoreboard players reset * parkour_end
 
 scoreboard players reset * particles
 scoreboard players reset * clear

--- a/pandamium_datapack/data/pandamium/functions/triggers/parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/parkour.mcfunction
@@ -1,0 +1,5 @@
+execute unless score @s parkour_checkpoint matches 0.. run tp @s -42.5 143 -90.5 45 12.5
+execute if score @s parkour_checkpoint matches 0.. run function pandamium:misc/map_specific/parkour/return_to_last_checkpoint
+
+scoreboard players reset @s parkour
+scoreboard players enable @s parkour

--- a/pandamium_datapack/data/pandamium/functions/triggers/parkour/checkpoint.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/parkour/checkpoint.mcfunction
@@ -1,4 +1,0 @@
-function pandamium:misc/map_specific/parkour/return_to_last_checkpoint
-
-scoreboard players reset @s parkour
-scoreboard players enable @s parkour

--- a/pandamium_datapack/data/pandamium/functions/triggers/parkour_end.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/parkour_end.mcfunction
@@ -1,3 +1,3 @@
 function pandamium:misc/map_specific/parkour/end_parkour
 
-scoreboard players reset @s parkour.end
+scoreboard players reset @s parkour_end


### PR DESCRIPTION
- `/trigger parkour` is now always enabled, and teleports you to the start if you're not on the parkour course
- Renamed trigger `parkour.end` to `parkour_end` and moved both trigger functions out of the `triggers/parkour` folder, and just into `triggers`