### PR TITLE
Fixed best time logic

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/finish_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/finish_parkour.mcfunction
@@ -1,4 +1,4 @@
-execute if score @s parkour_ticks < @s parkour_best_time run scoreboard players operation @s parkour_best_time = @s parkour_ticks
+execute unless score @s parkour_ticks >= @s parkour_best_time run scoreboard players operation @s parkour_best_time = @s parkour_ticks
 
 function pandamium:misc/map_specific/parkour/timer
 title @s actionbar ""


### PR DESCRIPTION
Fixed not working when `parkour_best_time` is _none_