### PR TITLE
Kill ender pearls on parkour start

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl.mcfunction
@@ -1,0 +1,4 @@
+data modify storage pandamium:temp NBT2 set from entity @s
+execute store success score <does_not_match> variable run data modify storage pandamium:temp NBT2.Owner set from storage pandamium:temp NBT.UUID
+
+execute if score <does_not_match> variable matches 0 run kill

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/kill_ender_pearls/main.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/kill_ender_pearls/main.mcfunction
@@ -1,0 +1,2 @@
+data modify storage pandamium:temp NBT set from entity @s
+execute as @e[type=ender_pearl] run function pandamium:misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/start_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/start_parkour.mcfunction
@@ -1,6 +1,8 @@
 scoreboard players set @s parkour_checkpoint 0
 execute at @s run playsound entity.player.levelup player @s ~ ~ ~ 1 2
 
+function pandamium:misc/map_specific/parkour/kill_ender_pearls/main
+
 scoreboard players enable @s parkour_end
 tellraw @s [{"text":"[Parkour] You started the parkour!","color":"aqua"},[{"text":"\n• If you cheat, you will quit the parkour. ","color":"dark_aqua"},{"text":"Hover your mouse here to see what counts as cheating.","hoverEvent":{"action":"show_text","value":"• Using an elytra\n• Using an ender pearl\n• Consuming a chorus fruit\n• Having the Speed or Jump Boost effects\n• Teleporting using a trigger\n• Leaving spawn\n• Changing gamemode (staff-only)"}},"\n• If you get stuck, run ",{"text":"/trigger parkour","color":"aqua"}," to return to your last checkpoint.\n• To quit the parkour course, run ",{"text":"/trigger parkour_end","color":"aqua"}," ",{"text":"(stops tracking time and resets checkpoints)","color":"gray"}]]
 execute if score @s parkour_best_time matches 1.. run function pandamium:misc/map_specific/parkour/print_best_time


### PR DESCRIPTION
Any thrown ender pearls belonging to the player should be killed when the player starts the parkour