### PR TITLE
Fixed rounding discrepancy

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/finish_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/finish_parkour.mcfunction
@@ -1,8 +1,8 @@
 execute unless score @s parkour_ticks >= @s parkour_best_time run scoreboard players operation @s parkour_best_time = @s parkour_ticks
 
-execute if score @s parkour_best_time matches 1.. run scoreboard players set @s parkour_leaderboard 0
-execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard -= @s parkour_best_time
+execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard = @s parkour_best_time
 execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard /= <ticks_per_second> variable
+execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard *= <-1> variable
 
 function pandamium:misc/map_specific/parkour/timer
 title @s actionbar ""

--- a/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -4,9 +4,9 @@ scoreboard players set @s new_world_tp 1
 
 # Migrate
 
-execute if score @s parkour_best_time matches 1.. run scoreboard players set @s parkour_leaderboard 0
-execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard -= @s parkour_best_time
+execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard = @s parkour_best_time
 execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard /= <ticks_per_second> variable
+execute if score @s parkour_best_time matches 1.. run scoreboard players operation @s parkour_leaderboard *= <-1> variable
 
 #
 


### PR DESCRIPTION
Fixed rounding discrepancy between `parkour_best_time` and `parkour_leaderboard` by making the latter value negative _after_ dividing, rather than before