### PR TITLE
Made afk tracking generic scoreboard

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -13,7 +13,7 @@ execute as @a[scores={alive=0}] unless score @s death_count matches 1.. run tp 0
 
 scoreboard players set Olexorus votes -1
 
-execute as @a unless entity @s[name=!XactivateG,name=!Wormcave,name=!Yuaichi,name=!Pandamiium,name=!Jardski,name=!Pure_Sun,name=!ChadGarion25,name=!BlockyBigBoy] run function pandamium:misc/afk_playtime
+execute as @a[scores={track_afk=1}] run function pandamium:misc/afk_playtime
 
 execute store result score <player_count> variable if entity @a
 function pandamium:misc/players_sleeping_percentage

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -156,6 +156,7 @@ scoreboard objectives add spawnpoint_y dummy
 scoreboard objectives add spawnpoint_z dummy
 scoreboard objectives add spawnpoint_dim dummy
 
+scoreboard objectives add track_afk dummy
 scoreboard objectives add afk_last_x dummy
 scoreboard objectives add afk_last_z dummy
 scoreboard objectives add afk_time dummy


### PR DESCRIPTION
Added [`track_afk`] scoreboard to store players (so I don't have to append usernames to this selector every time someone needs/wants to be added)