### PR TITLE
Restricted levitation advancement to outside of spawn

### DIFF
--- a/pandamium_datapack/data/minecraft/advancements/end/levitate.json
+++ b/pandamium_datapack/data/minecraft/advancements/end/levitate.json
@@ -1,0 +1,50 @@
+{
+	"display": {
+		"icon": {
+			"item": "shulker_shell"
+		},
+		"title": {
+			"translate": "advancements.end.levitate.title"
+		},
+		"description": {
+			"translate": "advancements.end.levitate.description"
+		},
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"parent": "end/find_end_city",
+	"criteria": {
+		"levitated": {
+			"trigger": "levitation",
+			"conditions": {
+				"player": [
+					{
+						"condition": "inverted",
+						"term": {
+							"condition": "entity_scores",
+							"entity": "this",
+							"scores": {
+								"in_spawn": 1
+							}
+						}
+					}
+				],
+				"distance": {
+					"y": {
+						"min": 50
+					}
+				}
+			}
+		}
+	},
+	"requirements": [
+		[
+			"levitated"
+		]
+	],
+	"rewards": {
+		"experience": 50
+	}
+}


### PR DESCRIPTION
This should prevent the wind tunnel from granting the advancement to players