### PR TITLE
Added more maze functionality 

### DIFF
--- a/pandamium_datapack/data/pandamium/advancements/maze/cheated.json
+++ b/pandamium_datapack/data/pandamium/advancements/maze/cheated.json
@@ -1,0 +1,59 @@
+{
+	"criteria": {
+		"consume_chorus_fruit": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"chorus_fruit"
+					]
+				}
+			}
+		},
+		"use_ender_pearl": {
+			"trigger": "tick",
+			"conditions": {
+				"player": [
+					{
+						"condition": "entity_scores",
+						"entity": "this",
+						"scores": {
+							"used.ender_pearl": {
+								"min": 1
+							}
+						}
+					}
+				]
+			}
+		},
+		"switch_gamemode": {
+			"trigger": "tick",
+			"conditions": {
+				"player": [
+					{
+						"condition": "inverted",
+						"term": {
+							"condition": "entity_properties",
+							"entity": "this",
+							"predicate": {
+								"player": {
+									"gamemode": "survival"
+								}
+							}
+						}
+					}
+				]
+			}
+		}
+	},
+	"requirements": [
+		[
+			"switch_gamemode",
+			"use_ender_pearl",
+			"consume_chorus_fruit"
+		]
+	],
+	"rewards": {
+		"function": "pandamium:misc/map_specific/maze/detect/cheated"
+	}
+}

--- a/pandamium_datapack/data/pandamium/advancements/parkour/cheated.json
+++ b/pandamium_datapack/data/pandamium/advancements/parkour/cheated.json
@@ -18,7 +18,7 @@
 						"condition": "entity_scores",
 						"entity": "this",
 						"scores": {
-							"parkour.aviate": {
+							"custom.aviate_one_cm": {
 								"min": 1
 							}
 						}
@@ -34,7 +34,7 @@
 						"condition": "entity_scores",
 						"entity": "this",
 						"scores": {
-							"parkour.used_ender_pearl": {
+							"used.ender_pearl": {
 								"min": 1
 							}
 						}

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/maze/detect/cheated.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/maze/detect/cheated.mcfunction
@@ -1,0 +1,10 @@
+scoreboard players reset @s used.ender_pearl
+
+tag @s add maze.this
+execute store success score <maze.can_run> variable if entity @p[tag=maze.this,x=-370,y=43,z=-83,dx=152,dy=6,dz=137]
+tag @s remove maze.this
+
+execute if score <maze.can_run> variable matches 1 run tp @s -201 44 -14 90 0
+execute if score <maze.can_run> variable matches 1 run tellraw @s [{"text":"[Maze]","color":"dark_red"},{"text":" Detected cheating!","color":"red"}]
+
+advancement revoke @s only pandamium:maze/cheated

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/detect/cheated.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/detect/cheated.mcfunction
@@ -3,7 +3,6 @@ scoreboard players reset @s used.ender_pearl
 
 scoreboard players set <parkour.can_run> variable 0
 execute if score @s parkour_checkpoint matches 0.. store success score <parkour.can_run> variable run function pandamium:misc/map_specific/parkour/end_parkour
-execute if score <parkour.can_run> variable matches 1 run function pandamium:misc/teleport/spawn
 execute if score <parkour.can_run> variable matches 1 run tp @s -42.5 143 -90.5 45 12.5
 execute if score <parkour.can_run> variable matches 1 run tellraw @s {"text":"(Cheating Detected)","color":"red"}
 

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/detect/cheated.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/detect/cheated.mcfunction
@@ -1,5 +1,5 @@
-scoreboard players reset @s parkour.aviate
-scoreboard players reset @s parkour.used_ender_pearl
+scoreboard players reset @s custom.aviate_one_cm
+scoreboard players reset @s used.ender_pearl
 
 scoreboard players set <parkour.can_run> variable 0
 execute if score @s parkour_checkpoint matches 0.. store success score <parkour.can_run> variable run function pandamium:misc/map_specific/parkour/end_parkour

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/run/checkpoint_pressure_plate.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/run/checkpoint_pressure_plate.mcfunction
@@ -2,8 +2,8 @@ execute if score @s parkour_checkpoint matches 0.. run scoreboard players operat
 scoreboard players add <next_checkpoint> variable 1
 
 scoreboard players reset <checkpoint_id> variable
-scoreboard players operation <checkpoint_id> variable = @e[type=marker,tag=parkour.checkpoint,distance=..1,limit=1] id
-execute store success score <parkour_finish> variable if data entity @e[type=marker,tag=parkour.checkpoint,distance=..1,limit=1] data{ParkourFinish:1b}
+scoreboard players operation <checkpoint_id> variable = @e[type=marker,tag=parkour.checkpoint,distance=..2,limit=1] id
+execute store success score <parkour_finish> variable if data entity @e[type=marker,tag=parkour.checkpoint,distance=..2,limit=1] data{ParkourFinish:1b}
 
 execute if score @s parkour_checkpoint matches 0.. if score <parkour_finish> variable matches 0 if score <checkpoint_id> variable matches 1.. if score <checkpoint_id> variable = <next_checkpoint> variable run function pandamium:misc/map_specific/parkour/new_checkpoint
 execute if score @s parkour_checkpoint matches 0.. if score <parkour_finish> variable matches 1 if score <checkpoint_id> variable matches 1.. if score <checkpoint_id> variable = <next_checkpoint> variable run function pandamium:misc/map_specific/parkour/finish_parkour

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -176,8 +176,9 @@ scoreboard objectives add parkour_ticks dummy
 scoreboard objectives add parkour_checkpoint dummy
 scoreboard objectives add parkour_best_time dummy
 scoreboard objectives add parkour_leaderboard dummy {"text":"Parkour Times","color":"blue","bold":true}
-scoreboard objectives add parkour.used_ender_pearl used:ender_pearl
-scoreboard objectives add parkour.aviate custom:aviate_one_cm
+
+scoreboard objectives add used.ender_pearl used:ender_pearl
+scoreboard objectives add custom.aviate_one_cm custom:aviate_one_cm
 
 scoreboard objectives add temp_1 dummy
 

--- a/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
@@ -2,5 +2,6 @@ scoreboard players set <can_accept> variable 1
 
 execute in pandamium:staff_world if entity @p[tag=receiver,x=0] unless entity @p[tag=sender,scores={staff_perms=1..}] run scoreboard players set <can_accept> variable 0
 execute in overworld if entity @p[tag=receiver,x=-166,y=-52,z=-110,dx=128,dy=75,dz=133] unless entity @p[tag=sender,scores={gameplay_perms=6..}] run scoreboard players set <can_accept> variable 0
+execute in overworld if entity @p[tag=receiver,x=-370,y=43,z=-83,dx=152,dy=6,dz=137] unless entity @p[tag=sender,advancements={pandamium:pandamium/map_specific/finish_maze=true}] run scoreboard players set <can_accept> variable 0
 execute if score @p[tag=receiver] jailed matches 1.. run scoreboard players set <can_accept> variable 0
 execute if score @p[tag=receiver] disable_tp_rqsts matches 1 run scoreboard players set <can_accept> variable 0


### PR DESCRIPTION
- Added cheat detection (ender pearls, chorus fruit, and switching gamemodes)
- You can no longer teleport to players who are in the maze unless you, yourself, have completed the maze
- Renamed `parkour.used_ender_pearl` and `parkour.aviate` to `used.ender_pearl` and `custom.aviate_one_cm` respectively
- Increased checkpoint detection range (should help with some checkpoints not activating properly)
- Removed an unnecessary teleport to spawn