### PR TITLE
You can no longer use home or tpa while on the parkour

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/home/go_check_exists.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/home/go_check_exists.mcfunction
@@ -13,8 +13,12 @@ execute if score @s home matches 10 if score @s home_10_x = @s home_10_x run fun
 
 execute if score <can_tp> variable matches 0 run tellraw @s [{"text":"[Home]","color":"dark_red"},{"text":" You have not set that home yet!","color":"red"}]
 
-# check if in donator area
-execute unless score @s gameplay_perms matches 6.. if score <tp_x> variable matches -190..-95 if score <tp_y> variable matches -64..16 if score <tp_z> variable matches -110..30 if score <tp_d> variable matches 0 run tellraw @s [{"text":"[Home]","color":"dark_red"},{"text":" Only donators can teleport here!","color":"red"}]
-execute unless score @s gameplay_perms matches 6.. if score <tp_x> variable matches -190..-95 if score <tp_y> variable matches -64..16 if score <tp_z> variable matches -110..30 if score <tp_d> variable matches 0 run scoreboard players set <can_tp> variable 0
+# Restrictions
+scoreboard players set <restricted> variable 0
+execute unless score <restricted> variable matches 1 store success score <restricted> variable if score @s jailed matches 1.. run tellraw @s [{"text":"[Home]","color":"dark_red"},{"text":" You cannot use that trigger in jail!","color":"red"}]
+execute unless score <restricted> variable matches 1 store success score <restricted> variable if score @s parkour_checkpoint matches 0.. run tellraw @s [{"text":"[Home]","color":"dark_red"},{"text":" You cannot use that trigger currently!","color":"red"}]
+execute unless score <restricted> variable matches 1 store success score <restricted> variable unless score @s gameplay_perms matches 6.. if score <tp_x> variable matches -166..-37 if score <tp_y> variable matches -52..-2 if score <tp_z> variable matches -110..24 if score <tp_d> variable matches 0 run tellraw @s [{"text":"[Home]","color":"dark_red"},{"text":" You cannot teleport here!","color":"red"}]
+
+execute if score <restricted> variable matches 1 run scoreboard players set <can_tp> variable 0
 
 execute if score <can_tp> variable matches 1 run function pandamium:home/go_run

--- a/pandamium_datapack/data/pandamium/functions/misc/get_jailed.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/get_jailed.mcfunction
@@ -4,3 +4,5 @@ execute store result score @s pre_jail_pos_x run data get entity @s Pos[0]
 execute store result score @s pre_jail_pos_y run data get entity @s Pos[1]
 execute store result score @s pre_jail_pos_z run data get entity @s Pos[2]
 scoreboard players operation @s pre_jail_pos_d = @s in_dimension
+
+execute if score @s parkour_checkpoint matches 0.. run function pandamium:misc/map_specific/parkour/end_parkour

--- a/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/tpa/check_can_accept.mcfunction
@@ -5,3 +5,4 @@ execute in overworld if entity @p[tag=receiver,x=-166,y=-52,z=-110,dx=128,dy=75,
 execute in overworld if entity @p[tag=receiver,x=-370,y=43,z=-83,dx=152,dy=6,dz=137] unless entity @p[tag=sender,advancements={pandamium:pandamium/map_specific/finish_maze=true}] run scoreboard players set <can_accept> variable 0
 execute if score @p[tag=receiver] jailed matches 1.. run scoreboard players set <can_accept> variable 0
 execute if score @p[tag=receiver] disable_tp_rqsts matches 1 run scoreboard players set <can_accept> variable 0
+execute if score @p[tag=sender] parkour_checkpoint matches 0.. run scoreboard players set <can_accept> variable 0


### PR DESCRIPTION
- You can no longer use `/trigger home` if you are on the parkour course
- You can no longer use `/trigger home` if you are jailed
- You can no longer accept TPA requests from players who are on the parkour course
- Jailed players will be kicked from the parkour course if they are on it
- Fixed home donator area restriction region