### PR TITLE
Changes to spawn / nether spawn

### DIFF
--- a/pandamium_datapack/data/pandamium/advancements/parkour/cheated.json
+++ b/pandamium_datapack/data/pandamium/advancements/parkour/cheated.json
@@ -121,16 +121,27 @@
 			"conditions": {
 				"player": [
 					{
-						"condition": "inverted",
-						"term": {
-							"condition": "entity_properties",
-							"entity": "this",
-							"predicate": {
-								"player": {
-									"gamemode": "survival"
+						"condition": "alternative",
+						"terms": [
+							{
+								"condition": "entity_properties",
+								"entity": "this",
+								"predicate": {
+									"player": {
+										"gamemode": "creative"
+									}
+								}
+							},
+							{
+								"condition": "entity_properties",
+								"entity": "this",
+								"predicate": {
+									"player": {
+										"gamemode": "spectator"
+									}
 								}
 							}
-						}
+						]
 					}
 				]
 			}

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/detect/checkpoint_pressure_plate.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/detect/checkpoint_pressure_plate.mcfunction
@@ -1,7 +1,7 @@
 execute if score @s parkour_checkpoint matches 0.. unless predicate pandamium:is_riding_entity run function pandamium:misc/map_specific/parkour/run/checkpoint_pressure_plate
 
 tag @s add parkour.running_function
-execute unless score @s parkour_checkpoint matches 0.. unless predicate pandamium:is_riding_entity if entity @p[tag=parkour.running_function,x=-46,y=142,z=-90,dx=2,dy=0,dz=2] run function pandamium:misc/map_specific/parkour/start_parkour
+execute unless score @s parkour_checkpoint matches 0.. unless predicate pandamium:is_riding_entity if entity @p[tag=parkour.running_function,x=-46,y=142,z=-90,dx=2,dy=0,dz=2,gamemode=!spectator,gamemode=!creative] run function pandamium:misc/map_specific/parkour/start_parkour
 tag @s remove parkour.running_function
 
 advancement revoke @s only pandamium:parkour/checkpoint_pressure_plate

--- a/pandamium_datapack/data/pandamium/functions/misc/player_regions/update_regions.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/player_regions/update_regions.mcfunction
@@ -1,6 +1,5 @@
-scoreboard players set @a in_nether_spawn 0
-execute in the_nether run scoreboard players set @a[x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] in_nether_spawn 1
-execute as @a run scoreboard players operation @s in_spawn = @s in_nether_spawn
+scoreboard players set @a in_spawn 0
+execute in the_nether run scoreboard players set @a[x=-512,y=0,z=-512,dx=1024,dy=256,dz=1024] in_spawn 1
 execute in overworld run scoreboard players set @a[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] in_spawn 1
 
 # Spawn Effects
@@ -9,8 +8,8 @@ execute as @a[scores={in_spawn=0}] run attribute @s generic.attack_damage base s
 
 # Nether Spawn Protection
 gamerule sendCommandFeedback false
-gamemode survival @a[gamemode=adventure,scores={in_nether_spawn=0}]
-gamemode adventure @a[gamemode=survival,scores={in_nether_spawn=1}]
+gamemode survival @a[gamemode=adventure,scores={in_spawn=0}]
+gamemode adventure @a[gamemode=survival,scores={in_spawn=1}]
 gamerule sendCommandFeedback true
 
 # Staff World Effects

--- a/pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -169,7 +169,6 @@ scoreboard objectives add on_join.take_items dummy
 scoreboard objectives add detect.leave_game custom:leave_game
 scoreboard objectives add detect.death deathCount
 scoreboard objectives add time_since_rest custom:time_since_rest
-scoreboard objectives add in_nether_spawn dummy
 scoreboard objectives add in_spawn dummy
 scoreboard objectives add in_dimension dummy
 scoreboard objectives add in_jail dummy
@@ -241,7 +240,6 @@ scoreboard players reset * switch_dimension
 scoreboard players reset * gameplay_perms
 scoreboard players reset * detect.leave_game
 scoreboard players reset * online_ticks
-scoreboard players reset * in_nether_spawn
 scoreboard players reset * in_dimension
 scoreboard players reset * in_jail
 scoreboard players reset * portal_ticks


### PR DESCRIPTION
- Removed `in_nether_spawn` objective
- Being in the overworld spawn also puts you in adventure mode, now
- The parkour now allows you to be in survival mode _or_ adventure mode
- You can no longer start the parkour if you are in creative mode