### PR TITLE
Changes to gameplay perms

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
@@ -20,6 +20,9 @@ scoreboard players set @s[team=member] gameplay_perms 2
 scoreboard players set @s[team=elder] gameplay_perms 3
 scoreboard players set @s[team=veteran] gameplay_perms 4
 execute unless entity @s[team=!elite,team=!helper] run scoreboard players set @s gameplay_perms 5
+
 scoreboard players set @s[team=vip] gameplay_perms 6
 scoreboard players set @s[scores={donator=1}] gameplay_perms 6
 execute if score @s staff_perms matches 2.. unless score @s staff_alt matches 1 run scoreboard players set @s gameplay_perms 6
+
+scoreboard players set @s[scores={staff_alt=1,gameplay_perms=..2}] gameplay_perms 3

--- a/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
@@ -14,7 +14,7 @@ scoreboard players set @s[team=srmod] staff_perms 3
 scoreboard players set @s[team=admin] staff_perms 4
 scoreboard players set @s[team=owner] staff_perms 5
 
-scoreboard players reset @s gameplay_perms
+scoreboard players set @s gameplay_perms 0
 scoreboard players set @s[team=player] gameplay_perms 1
 scoreboard players set @s[team=member] gameplay_perms 2
 scoreboard players set @s[team=elder] gameplay_perms 3
@@ -22,4 +22,4 @@ scoreboard players set @s[team=veteran] gameplay_perms 4
 execute unless entity @s[team=!elite,team=!helper] run scoreboard players set @s gameplay_perms 5
 scoreboard players set @s[team=vip] gameplay_perms 6
 scoreboard players set @s[scores={donator=1}] gameplay_perms 6
-scoreboard players set @s[scores={staff_perms=2..}] gameplay_perms 6
+execute if score @s staff_perms matches 2.. unless score @s staff_alt matches 1 run scoreboard players set @s gameplay_perms 6


### PR DESCRIPTION
- Default gameplay perms is `0`, not null
- Minimum gameplay perms for staff alts is now `3` (same as the Elder rank)