### PR TITLE
Staff fixes

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
@@ -7,6 +7,7 @@ execute if entity @s[team=member] if score @s votes matches 125.. if score @s pl
 execute if entity @s[team=elder] if score @s votes matches 500.. if score @s playtime_ticks matches 36000000.. run team join veteran
 execute if entity @s[team=veteran] if score @s votes matches 2500.. if score @s playtime_ticks matches 180000000.. run team join elite
 
+# Staff Perms
 execute unless score @s staff_alt matches 1 run scoreboard players set @s staff_perms 0
 scoreboard players set @s[team=helper] staff_perms 1
 scoreboard players set @s[team=mod] staff_perms 2
@@ -14,6 +15,10 @@ scoreboard players set @s[team=srmod] staff_perms 3
 scoreboard players set @s[team=admin] staff_perms 4
 scoreboard players set @s[team=owner] staff_perms 5
 
+execute unless entity @s[team=!helper,team=!mod,team=!srmod,team=!admin,team=!owner] if score @s staff_alt matches 1 run tellraw @s [{"text":"[Info]","color":"dark_red"},{"text":" Your [staff_alt] score has been reset, as it is incompatible with your team!"}]
+execute unless entity @s[team=!helper,team=!mod,team=!srmod,team=!admin,team=!owner] if score @s staff_alt matches 1 run scoreboard players reset @s staff_alt
+
+# Gameplay Perms
 scoreboard players set @s gameplay_perms 0
 scoreboard players set @s[team=player] gameplay_perms 1
 scoreboard players set @s[team=member] gameplay_perms 2

--- a/pandamium_datapack/data/pandamium/functions/triggers/toggle_spectator.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/triggers/toggle_spectator.mcfunction
@@ -4,9 +4,9 @@ execute store success score <can_run> variable if score @s staff_perms matches 2
 execute if predicate pandamium:in_spawn run scoreboard players set <can_run> variable 1
 execute if score @s in_dimension matches 2 run scoreboard players set <can_run> variable 1
 
-execute if score <can_run> variable matches 1 if score <toggle_gamemode> variable matches 0 run gamemode survival
-execute if score <can_run> variable matches 1 if score <toggle_gamemode> variable matches 0 run effect clear @s night_vision
-execute if score <can_run> variable matches 1 if score <toggle_gamemode> variable matches 1 run gamemode spectator
+execute if score <can_run> variable matches 1 if score <in_spectator_mode> variable matches 1 run gamemode survival
+execute if score <can_run> variable matches 1 if score <in_spectator_mode> variable matches 1 run effect clear @s night_vision
+execute if score <can_run> variable matches 1 if score <in_spectator_mode> variable matches 0 run gamemode spectator
 
 execute if score <can_run> variable matches 0 run tellraw @s [{"text":"[Info]","color":"dark_red","clickEvent":{"action":"run_command","value":"/trigger spawn set -1"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Spawn","bold":true}," in spectator mode"]}},{"text":" Helpers can only use spectator mode at spawn and in the staff world!","color":"red"}]
 


### PR DESCRIPTION
- When updating perms, `staff_alt` is reset if they are in a staff rank (since they are incompatible and would lead to incorrect gameplay perms)
- Fixed `/trigger toggle_spectator`