### PR TITLE
Fixed ender pearl issues

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/maze/detect/cheated.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/maze/detect/cheated.mcfunction
@@ -1,10 +1,13 @@
 scoreboard players reset @s detect.used.ender_pearl
 
 tag @s add maze.this
-execute store success score <maze.can_run> variable in overworld if entity @p[tag=maze.this,x=-370,y=43,z=-83,dx=152,dy=6,dz=137]
+execute store success score <in_maze> variable in overworld if entity @p[tag=maze.this,x=-370,y=43,z=-83,dx=152,dy=6,dz=137]
 tag @s remove maze.this
 
-execute if score <maze.can_run> variable matches 1 run tp @s -201 44 -14 90 0
-execute if score <maze.can_run> variable matches 1 run tellraw @s [{"text":"[Maze]","color":"dark_red"},{"text":" Detected cheating!","color":"red"}]
+execute if score <in_maze> variable matches 1 run data modify storage pandamium:temp NBT set from entity @s
+execute if score <in_maze> variable matches 1 as @e[type=ender_pearl,x=-370,y=43,z=-83,dx=152,dy=6,dz=137] run function pandamium:misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl
+
+execute if score <in_maze> variable matches 1 run tp @s -201 44 -14 90 0
+execute if score <in_maze> variable matches 1 run tellraw @s [{"text":"[Maze]","color":"dark_red"},{"text":" Detected cheating!","color":"red"}]
 
 advancement revoke @s only pandamium:detect/maze/cheated

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/start_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/start_parkour.mcfunction
@@ -9,4 +9,4 @@ execute if score @s parkour_best_time matches 1.. run function pandamium:misc/ma
 function pandamium:misc/count_filled_inventory_slots
 execute if data storage pandamium:temp NBT.Inventory[{Slot:102b,id:'minecraft:elytra'}] unless score <filled_inventory_slots> variable matches 36.. in pandamium:staff_world run function pandamium:misc/unequip_chest_slot
 execute if data storage pandamium:temp NBT.Inventory[{Slot:102b,id:'minecraft:elytra'}] unless score <filled_inventory_slots> variable matches 36.. run tellraw @s [{"text":"[Parkour]","color":"blue"},{"text":" Unequipped your elytra!","color":"green"}]
-execute as @e[type=ender_pearl] run function pandamium:misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl
+execute as @e[type=ender_pearl,x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl


### PR DESCRIPTION
- Ender pearls are killed in the maze when thrown
- Ender pearls are only searched for at spawn or in the maze chunks (perf)