### PR TITLE
Fixes for ender pearls

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/maze/detect/cheated.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/maze/detect/cheated.mcfunction
@@ -4,9 +4,7 @@ tag @s add maze.this
 execute store success score <in_maze> variable in overworld if entity @p[tag=maze.this,x=-370,y=43,z=-83,dx=152,dy=6,dz=137]
 tag @s remove maze.this
 
-execute if score <in_maze> variable matches 1 run data modify storage pandamium:temp NBT set from entity @s
-execute if score <in_maze> variable matches 1 as @e[type=ender_pearl,x=-370,y=43,z=-83,dx=152,dy=6,dz=137] run function pandamium:misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl
-
+execute if score <in_maze> variable matches 1 run kill @e[type=ender_pearl,x=-370,y=43,z=-83,dx=152,dy=6,dz=137]
 execute if score <in_maze> variable matches 1 run tp @s -201 44 -14 90 0
 execute if score <in_maze> variable matches 1 run tellraw @s [{"text":"[Maze]","color":"dark_red"},{"text":" Detected cheating!","color":"red"}]
 

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/end_parkour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/end_parkour.mcfunction
@@ -3,6 +3,8 @@ scoreboard players reset @s parkour_end
 scoreboard players reset @s parkour_checkpoint
 scoreboard players reset @s parkour_ticks
 
+data modify storage pandamium:temp NBT set from entity @s
+execute as @e[type=ender_pearl,x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl
+
 title @s actionbar ""
 tellraw @s [{"text":"[Parkour]","color":"dark_red"},{"text":" Ended parkour!","color":"red"}]
-

--- a/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/map_specific/parkour/kill_ender_pearls/as_ender_pearl.mcfunction
@@ -1,4 +1,4 @@
-data modify storage pandamium:temp NBT2 set from entity @s
-execute store success score <does_not_match> variable run data modify storage pandamium:temp NBT2.Owner set from storage pandamium:temp NBT.UUID
+data modify storage pandamium:temp Owner set from entity @s Owner
+execute store success score <does_not_match> variable run data modify storage pandamium:temp Owner set from storage pandamium:temp NBT.UUID
 
 execute if score <does_not_match> variable matches 0 run kill


### PR DESCRIPTION
- Simplified how ender pearls are killed in the maze
- Own ender pearls are killed when ending your parkour run 