### PR TITLE
1.18.2

### DIFF
--- a/pandamium_datapack/data/pandamium/dimension/staff_world.json
+++ b/pandamium_datapack/data/pandamium/dimension/staff_world.json
@@ -1,8 +1,7 @@
 {
-	"type": "pandamium:staff_world",
+	"type": "pandamium:void",
 	"generator": {
 		"type": "flat",
-		"seed": -1148089079,
 		"settings": {
 			"biome": "the_void",
 			"features": false,

--- a/pandamium_datapack/data/pandamium/dimension_type/void.json
+++ b/pandamium_datapack/data/pandamium/dimension_type/void.json
@@ -8,10 +8,9 @@
 	"has_skylight": true,
 	"has_ceiling": false,
 	"coordinate_scale": 1,
-	"ambient_light": 15,
-	"fixed_time": 6000,
-	"logical_height": 256,
-	"infiniburn": "infiniburn_overworld",
-	"min_y": 0,
-	"height": 256
+	"ambient_light": 0.5,
+	"logical_height": 384,
+	"infiniburn": "#infiniburn_overworld",
+	"min_y": -64,
+	"height": 384
 }

--- a/pandamium_datapack/pack.mcmeta
+++ b/pandamium_datapack/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
         "description": "Pandamium Datapack\n§8Server: §nsnapshot.pandamium.eu§r",
-        "pack_format": 8
+        "pack_format": 9
     }
 }


### PR DESCRIPTION
- Updated pack format.
- Fixed `dimension_type` file for 1.18.2.

- Made some changes to the staff world:
  - Renamed the `staff_world.json` `dimension_type` to `void.json` and changed the `type` field in the staff_world dimension accordingly.
  - Removed `fixed_time` for the staff world.
  - Changed `ambient_light` to the default overworld value.
  - Increased world height to be the same as the overworld (testing suggests it should not cause a problem for the existing chunks).