### PR TITLE
Fixed elytra deletion

### DIFF
--- a/pandamium_datapack/data/pandamium/functions/misc/count_filled_inventory_slots.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/count_filled_inventory_slots.mcfunction
@@ -9,5 +9,7 @@ data remove storage pandamium:temp count.NBT.Inventory[{Slot:103b}]
 data remove storage pandamium:temp count.NBT.Inventory[{Slot:-106b}]
 
 execute store result score <filled_inventory_slots> variable run data get storage pandamium:temp count.NBT.Inventory
+scoreboard players set <empty_inventory_slots> variable 36
+scoreboard players operation <empty_inventory_slots> variable -= <filled_inventory_slots> variable
 
 data modify storage pandamium:temp count.NBT set from storage pandamium:temp count.NBT_backup

--- a/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/cancel/failed_to_unequip_elytra.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/cancel/failed_to_unequip_elytra.mcfunction
@@ -1,0 +1,2 @@
+function pandamium:misc/parkour/actions/cancel
+tellraw @s [{"text":"[Parkour] ","color":"dark_red"},{"text":"Ended parkour! Could not unequip your elytra as there was not enough room in your inventory.","color":"red"}]

--- a/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/cheat.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/cheat.mcfunction
@@ -1,0 +1,24 @@
+execute if score @s parkour.checkpoint matches 0..99 run function pandamium:misc/parkour/parkour_1/tp_to_start
+execute if score @s parkour.checkpoint matches 0..99 run tp @s
+execute if score @s parkour.checkpoint matches 0..99 run function pandamium:misc/parkour/actions/cancel/cheating
+
+# Monstrosity Parkour
+# `pandamium:misc/count_filled_inventory_slots` sets `pandamium:temp count.NBT` from entity @s
+execute if score @s parkour.checkpoint matches 100..199 if score @s detect.aviate matches 1.. run function pandamium:misc/count_filled_inventory_slots
+execute if score @s parkour.checkpoint matches 100..199 if score @s detect.aviate matches 1.. if score <empty_inventory_slots> variable matches 1.. in pandamium:staff_world run function pandamium:misc/unequip_chest_slot
+execute if score @s parkour.checkpoint matches 100..199 if score @s detect.aviate matches 1.. if score <empty_inventory_slots> variable matches 1.. run tellraw @s [{"text":"[Parkour]","color":"dark_red"},{"text":" Unequipped your elytra!","color":"red"}]
+execute if score @s parkour.checkpoint matches 100..199 if score @s detect.aviate matches 1.. unless score <empty_inventory_slots> variable matches 1.. run function pandamium:misc/parkour/actions/cancel/failed_to_unequip_elytra
+
+execute if score @s parkour.checkpoint matches 100..199 if entity @s[gamemode=adventure] run tellraw @s [{"text":"[Parkour] ","color":"dark_red"},[{"text":"Cheating was detected! Returned you to the beginning of the room and gave you a ","color":"red"},{"text":"15 second time penalty","bold":true},"."]]
+execute if score @s parkour.checkpoint matches 100..199 if entity @s[gamemode=adventure] run scoreboard players add @s parkour.timer_ticks 300
+execute if score @s parkour.checkpoint matches 100..199 if entity @s[gamemode=adventure] run function pandamium:misc/parkour/actions/return_to_last_checkpoint
+execute if score @s parkour.checkpoint matches 100..199 unless entity @s[gamemode=adventure] run function pandamium:misc/parkour/actions/cancel/cheating
+
+# Kill thrown ender pearls
+execute if score @s detect.used.ender_pearl matches 1.. run data modify storage pandamium:temp UUID set from entity @s UUID
+execute if score @s detect.used.ender_pearl matches 1.. as @e[type=ender_pearl,x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/parkour/kill_ender_pearl
+
+# Resets velocity
+tp @s
+
+execute at @s run playsound block.note_block.didgeridoo master @s ~ ~ ~ 1 0

--- a/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/start.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/start.mcfunction
@@ -16,8 +16,8 @@ execute at @s run playsound entity.player.levelup master @s ~ ~ ~ 1 2
 
 # `pandamium:misc/count_filled_inventory_slots` sets `pandamium:temp count.NBT` from entity @s
 function pandamium:misc/count_filled_inventory_slots
-execute if data storage pandamium:temp count.NBT.Inventory[{Slot:102b,id:'minecraft:elytra'}] unless score <filled_inventory_slots> variable matches 36.. in pandamium:staff_world run function pandamium:misc/unequip_chest_slot
-execute if data storage pandamium:temp count.NBT.Inventory[{Slot:102b,id:'minecraft:elytra'}] unless score <filled_inventory_slots> variable matches 36.. run tellraw @s [{"text":"[Parkour]","color":"aqua"},{"text":" Unequipped your elytra!","color":"dark_aqua"}]
+execute if data storage pandamium:temp count.NBT.Inventory[{Slot:102b,id:'minecraft:elytra'}] if score <empty_inventory_slots> variable matches 1.. in pandamium:staff_world run function pandamium:misc/unequip_chest_slot
+execute if data storage pandamium:temp count.NBT.Inventory[{Slot:102b,id:'minecraft:elytra'}] if score <empty_inventory_slots> variable matches 1.. run tellraw @s [{"text":"[Parkour]","color":"aqua"},{"text":" Unequipped your elytra!","color":"dark_aqua"}]
 scoreboard players reset @s detect.aviate
 
 data modify storage pandamium:temp UUID set from storage pandamium:temp count.NBT.UUID

--- a/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/unequip_armour.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/parkour/actions/unequip_armour.mcfunction
@@ -4,6 +4,6 @@ function pandamium:misc/count_filled_inventory_slots
 scoreboard players set <is_wearing_armour> variable 1
 execute unless data storage pandamium:temp count.NBT.Inventory[{Slot:100b}] unless data storage pandamium:temp count.NBT.Inventory[{Slot:101b}] unless data storage pandamium:temp count.NBT.Inventory[{Slot:102b}] unless data storage pandamium:temp count.NBT.Inventory[{Slot:103b}] run scoreboard players set <is_wearing_armour> variable 0
 
-execute if score <is_wearing_armour> variable matches 1 if score <filled_inventory_slots> variable matches ..32 in pandamium:staff_world run function pandamium:misc/unequip_all
-execute if score <is_wearing_armour> variable matches 1 if score <filled_inventory_slots> variable matches ..32 run tellraw @s [{"text":"[Parkour]","color":"aqua"},{"text":" Unequipped your armour!","color":"dark_aqua"}]
-execute if score <is_wearing_armour> variable matches 1 unless score <filled_inventory_slots> variable matches ..32 run tellraw @s [{"text":"[Parkour]","color":"dark_red"},{"text":" Take off your armour before attempting this section otherwise it will be damaged by the cacti!","color":"red"}]
+execute if score <is_wearing_armour> variable matches 1 if score <empty_inventory_slots> variable matches 4.. in pandamium:staff_world run function pandamium:misc/unequip_all
+execute if score <is_wearing_armour> variable matches 1 if score <empty_inventory_slots> variable matches 4.. run tellraw @s [{"text":"[Parkour]","color":"aqua"},{"text":" Unequipped your armour!","color":"dark_aqua"}]
+execute if score <is_wearing_armour> variable matches 1 unless score <empty_inventory_slots> variable matches 4.. run tellraw @s [{"text":"[Parkour]","color":"dark_red"},{"text":" Take off your armour before attempting this section otherwise it will be damaged by the cacti!","color":"red"}]

--- a/pandamium_datapack/data/pandamium/functions/misc/parkour/detect/cheat.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/parkour/detect/cheat.mcfunction
@@ -1,26 +1,7 @@
-execute store success score <in_parkour> variable if score @s parkour.checkpoint matches 0..
-
-execute if score <in_parkour> variable matches 1 if score @s detect.aviate matches 1.. run function pandamium:misc/unequip_chest_slot
+execute if score @s parkour.checkpoint matches 0.. run function pandamium:misc/parkour/actions/cheat
 
 scoreboard players reset @s detect.aviate
 scoreboard players reset @s detect.used.ender_pearl
 scoreboard players reset @s detect.used.trident
-
-execute if score <in_parkour> variable matches 1 if score @s parkour.checkpoint matches 0..99 run function pandamium:misc/parkour/parkour_1/tp_to_start
-execute if score <in_parkour> variable matches 1 if score @s parkour.checkpoint matches 0..99 run tp @s
-execute if score <in_parkour> variable matches 1 if score @s parkour.checkpoint matches 0..99 run function pandamium:misc/parkour/actions/cancel/cheating
-
-execute if score <in_parkour> variable matches 1 if score @s parkour.checkpoint matches 100..199 if entity @s[gamemode=adventure] run tellraw @s [{"text":"[Parkour] ","color":"dark_red"},[{"text":"Cheating was detected! Returned you to the beginning of the room and gave you a ","color":"red"},{"text":"15 second time penalty","bold":true},"."]]
-execute if score <in_parkour> variable matches 1 if score @s parkour.checkpoint matches 100..199 if entity @s[gamemode=adventure] run scoreboard players add @s parkour.timer_ticks 300
-execute if score <in_parkour> variable matches 1 if score @s parkour.checkpoint matches 100..199 if entity @s[gamemode=adventure] run function pandamium:misc/parkour/actions/return_to_last_checkpoint
-execute if score <in_parkour> variable matches 1 if score @s parkour.checkpoint matches 100..199 unless entity @s[gamemode=adventure] run function pandamium:misc/parkour/actions/cancel/cheating
-
-execute if score <in_parkour> variable matches 1 run data modify storage pandamium:temp UUID set from entity @s UUID
-execute if score <in_parkour> variable matches 1 as @e[type=ender_pearl,x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/parkour/kill_ender_pearl
-
-# Resets velocity
-execute if score <in_parkour> variable matches 1 run tp @s
-
-execute if score <in_parkour> variable matches 1 at @s run playsound block.note_block.didgeridoo master @s ~ ~ ~ 1 0
 
 advancement revoke @s only pandamium:detect/parkour/cheat

--- a/pandamium_datapack/data/pandamium/functions/misc/unequip_chest_slot.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/unequip_chest_slot.mcfunction
@@ -3,6 +3,8 @@
 # If there is not at least 1 empty inventory slot, the items will be deleted without warning. Use the function "pandamium:misc/count_filled_inventory_slots" to check how many slots are available before running this function.
 
 setblock 0 0 0 shulker_box
+
 item replace block 0 0 0 container.0 from entity @s armor.chest
 item replace entity @s armor.chest with air
+
 loot give @s mine 0 0 0 air{drop_contents:1b}

--- a/pandamium_datapack/data/pandamium/functions/misc/vote_shop/check_requirements.mcfunction
+++ b/pandamium_datapack/data/pandamium/functions/misc/vote_shop/check_requirements.mcfunction
@@ -12,7 +12,7 @@ data modify storage pandamium:temp NBT set from storage pandamium:temp count.NBT
 
 # Check requirements
 execute if score <can_buy> variable matches 1 if score @s vote_credits < <cost> variable run scoreboard players set <can_buy> variable 0
-execute if score <can_buy> variable matches 1 if score <gives_item> variable matches 1 if score <filled_inventory_slots> variable matches 36.. run scoreboard players set <can_buy> variable 0
+execute if score <can_buy> variable matches 1 if score <gives_item> variable matches 1 if score <empty_inventory_slots> variable matches 0 run scoreboard players set <can_buy> variable 0
 execute if score <can_buy> variable matches 1 if score @s jailed matches 1.. run scoreboard players set <can_buy> variable 0
 execute if score <can_buy> variable matches 1 if score @s parkour.checkpoint matches 0.. run scoreboard players set <can_buy> variable 0
 execute if score <can_buy> variable matches 1 if entity @s[gamemode=spectator] run scoreboard players set <can_buy> variable 0


### PR DESCRIPTION
- Elytra should no longer be deleted if your inventory is full and you cheat on the parkour
- The Monstrosity parkour will end if you cheat with elytra on. Otherwise, they would get spammed with cheating messages since their elytra are not removed.
- Most of the cheating parkour code is now only run when you're actually on the course
- Added `<empty_inventory_slots>` variable from `count_filled_inventory_slots` (`36 - <filled_inventory_slots>`) for easier readability in functions that require N number of empty slots