### PR TITLE
Changes to loop frequency, and scoreboard next_id migration

### DIFF
--- a/release_pandamium_datapack/data/minecraft/tags/functions/tick.json
+++ b/release_pandamium_datapack/data/minecraft/tags/functions/tick.json
@@ -1,5 +1,5 @@
 {
     "values": [
-        "pandamium:main_loop"
+        "pandamium:tick_loop"
     ]
 }

--- a/release_pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -1,0 +1,1 @@
+execute if score @s debug matches 1.. run function pandamium:triggers/debug

--- a/release_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -1,9 +1,8 @@
-# Manage player ids
-scoreboard players add @a id 0
-execute as @a[scores={id=..0}] run function pandamium:misc/assign_id
+# Manage IDs and joining
+execute as @a unless score @s detect.leave_game matches 0 run function pandamium:on_join
 
-# Disable tnt
-execute as @e[type=#pandamium:tnt] at @s run function pandamium:misc/defuse_tnt
+# Triggers
+execute as @a at @s run function pandamium:check_triggers
 
 # Random TP
 execute as @a[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium:misc/teleport/random/check_in_teleporter
@@ -11,3 +10,6 @@ execute as @a[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] run function pandamium
 # Spawn effects and no mobs
 execute as @a[predicate=pandamium:in_spawn] run function pandamium:misc/spawn_effects
 tp @e[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024,type=#pandamium:remove_at_spawn,tag=!spawn_protected] 0 -1000 0
+
+
+schedule function pandamium:main_loop 5t

--- a/release_pandamium_datapack/data/pandamium/functions/misc/assign_id.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/misc/assign_id.mcfunction
@@ -1,2 +1,2 @@
-scoreboard players operation @s id = <nextId> id
-scoreboard players add <nextId> id 1
+scoreboard players operation @s id = <next_id> global
+scoreboard players add <next_id> global 1

--- a/release_pandamium_datapack/data/pandamium/functions/misc/spawn_effects.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/misc/spawn_effects.mcfunction
@@ -1,4 +1,5 @@
 effect give @s resistance 1 4 true
-effect give @s fire_resistance 1 0 true
-effect give @s saturation 2 100 true
+effect give @s saturation 6 0 true
 effect give @s[gamemode=!creative] weakness 1 100 true
+effect give @s conduit_power 1 0 true
+effect give @s fire_resistance 1 0 true

--- a/release_pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -1,0 +1,10 @@
+execute unless score @s id matches 1.. run function pandamium:misc/assign_id
+
+# Triggers
+scoreboard players enable @s[name=DorkOrc] debug
+#scoreboard players enable @s item_font
+#scoreboard players enable @s sign_font
+
+#
+
+scoreboard players set @s detect.leave_game 0

--- a/release_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -1,4 +1,30 @@
+# Scoreboards
 scoreboard objectives add id dummy
 scoreboard objectives add variable dummy
+scoreboard objectives add global dummy
+
+execute unless score <next_id> global matches 2.. run scoreboard players set <next_id> variable 2
+
+scoreboard objectives add detect.leave_game custom:leave_game
+
+scoreboard objectives add debug trigger
+#scoreboard objectives add item_font trigger
+#scoreboard objectives add sign_font trigger
+
+# Reset Scoreboards
+scoreboard players reset * detect.leave_game
+
+scoreboard players reset * debug
+#scoreboard players reset * item_font
+#scoreboard players reset * sign_font
+
+
+# Migrate <nextID> id -> <next_id> global
+execute unless score <next_id> global matches 2.. if score <nextId> id = <nextId> id run scoreboard players operation <next_id> global = <nextId> id
+execute if score <nextId> id = <nextId> id run scoreboard players reset <nextId> id
+
+#
 
 execute in pandamium:staff_world run forceload add -1 -1 0 0
+
+function pandamium:main_loop

--- a/release_pandamium_datapack/data/pandamium/functions/tick_loop.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/tick_loop.mcfunction
@@ -1,0 +1,2 @@
+# Disable tnt
+execute as @e[type=#pandamium:tnt] at @s run function pandamium:misc/defuse_tnt

--- a/release_pandamium_datapack/data/pandamium/functions/triggers/debug.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/triggers/debug.mcfunction
@@ -1,0 +1,5 @@
+tellraw @s ["",{"text":"<nextId>","color":"aqua"}," ",{"text":"id","color":"yellow"}," = ",{"score":{"name":"<nextId>","objective":"id"}}]
+tellraw @s ["",{"text":"<next_id>","color":"aqua"}," ",{"text":"global","color":"yellow"}," = ",{"score":{"name":"<next_id>","objective":"global"}}]
+
+scoreboard players reset @s debug
+scoreboard players enable @s[name=DorkOrc] debug


### PR DESCRIPTION
- Renamed `main_loop` to `tick_loop`
  - Only tnt is handled in this loop, now
- Added `main_loop` which repeats every 5 ticks
  - Most stuff will use this loop
- Changed spawn effects to match the snapshot server
- Changed `<nextId> id` to `<next_id> global`, and added temporary migration code for this