### PR TITLE
22w12a

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/tags/entity_types/remove_at_spawn.json
+++ b/snapshot_pandamium_datapack/data/pandamium/tags/entity_types/remove_at_spawn.json
@@ -4,6 +4,7 @@
 		"blaze",
 		"boat",
 		"cave_spider",
+		"chest_boat",
 		"creeper",
 		"drowned",
 		"elder_guardian",

--- a/snapshot_pandamium_datapack/data/vanilla/loot_tables/entities/warden.json
+++ b/snapshot_pandamium_datapack/data/vanilla/loot_tables/entities/warden.json
@@ -1,0 +1,3 @@
+{
+  "type": "minecraft:entity"
+}


### PR DESCRIPTION
- Updated vanilla loot tables
- Added `chest_boat` to the `remove_at_spawn` tag with the regular `boat`