### PR TITLE
Added air_like block tag

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/tags/blocks/air_like.json
+++ b/snapshot_pandamium_datapack/data/pandamium/tags/blocks/air_like.json
@@ -1,0 +1,8 @@
+{
+	"values": [
+		"air",
+		"cave_air",
+		"void_air",
+		"light"
+	]
+}


### PR DESCRIPTION
Should fix the output log error and should let the parkour saving y offset function properly