### PR TITLE
Staff Fixes

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/gift/receive_vote_credit.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/gift/receive_vote_credit.mcfunction
@@ -2,5 +2,5 @@ tellraw @s [{"text":"","color":"green"},{"text":"[Gift] ","color":"blue"},{"sele
 
 scoreboard players add @s vote_credits 1
 
-execute anchored eyes run particle heart ^ ^ ^ 0.3 0.3 0.3 0 5
+execute unless entity @s[gamemode=spectator] unless score @s hidden matches 1.. anchored eyes run particle heart ^ ^ ^ 0.3 0.3 0.3 0 5
 playsound entity.experience_orb.pickup master @s ~ ~ ~ 1 1.7

--- a/snapshot_pandamium_datapack/data/pandamium/functions/triggers/gift.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/triggers/gift.mcfunction
@@ -14,7 +14,7 @@ execute if score <returned> variable matches 0 store success score <returned> va
 execute if score <returned> variable matches 0 as @p[tag=selected_player] at @s run function pandamium:misc/gift/receive_vote_credit
 execute if score <returned> variable matches 0 run scoreboard players remove @s vote_credits 1
 execute if score <returned> variable matches 0 run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Gift]","color":"blue"}," You gifted ",{"selector":"@p[tag=selected_player]"}," a ",{"text":"vote credit","color":"aqua"},"! You now have ",{"score":{"name":"@s","objective":"vote_credits"},"bold":true,"color":"aqua"}," vote credit",{"text":"(s)","color":"gray"},"! ",[{"text":"(-","color":"red"},{"text":"1","bold":true},")"]]
-execute if score <returned> variable matches 0 anchored eyes run particle heart ^ ^ ^ 0.3 0.3 0.3 0 5
+execute if score <returned> variable matches 0 unless entity @s[gamemode=spectator] unless score @s hidden matches 1.. anchored eyes run particle heart ^ ^ ^ 0.3 0.3 0.3 0 5
 execute if score <returned> variable matches 0 run scoreboard players set @s gift_cooldown 18000
 
 #

--- a/snapshot_pandamium_datapack/data/pandamium/functions/triggers/jail.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/triggers/jail.mcfunction
@@ -1,7 +1,7 @@
 # run AT @s
 
 tag @s add running_trigger
-scoreboard players set <returned> variable
+scoreboard players set <returned> variable 0
 
 # positive -> jail_type=1
 # negative -> jail_type=2
@@ -20,15 +20,16 @@ execute if score <returned> variable matches 0 run scoreboard players set <playe
 execute if score <returned> variable matches 0 if score @s jail matches 2.. as @a if score @s id = @p[tag=running_trigger] jail store success score <player_exists> variable run tag @s add selected_player
 execute if score <returned> variable matches 0 store success score <returned> variable if score <player_exists> variable matches 0 run tellraw @s [{"text":"[Jail]","color":"dark_red"},[{"text":" Could not find a player with ID ","color":"red"},{"score":{"name":"@s","objective":"jail"}},"!"]]
 
-execute as @p[tag=selected_player] run scoreboard players operation <player_in_jail> variable = @s jailed
+execute if score <returned> variable matches 0 as @p[tag=selected_player] run scoreboard players operation <player_in_jail> variable = @s jailed
 
+execute if score <returned> variable matches 0 run scoreboard players operation @p[tag=selected_player] jailed = <jail_type> variable
 execute if score <returned> variable matches 0 store success score <returned> variable if score <player_in_jail> variable matches 1.. unless score <player_in_jail> variable = <jail_type> variable if score <jail_type> variable matches 1 run tellraw @s [{"text":"[Jail]","color":"gold","clickEvent":{"action":"run_command","value":"/trigger spawn set -101"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Jail Area","bold":true,"color":"gold"}," in spectator mode"]}},[{"text":" Moved ","color":"yellow"},{"selector":"@p[tag=selected_player]"}," to the main jail!"]]
 execute if score <returned> variable matches 0 store success score <returned> variable if score <player_in_jail> variable matches 1.. unless score <player_in_jail> variable = <jail_type> variable if score <jail_type> variable matches 2 run tellraw @s [{"text":"[Jail]","color":"gold","clickEvent":{"action":"run_command","value":"/trigger spawn set -101"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Jail Area","bold":true,"color":"gold"}," in spectator mode"]}},[{"text":" Moved ","color":"yellow"},{"selector":"@p[tag=selected_player]"}," to the questioning jail!"]]
+
 execute if score <returned> variable matches 0 store success score <returned> variable if score <player_in_jail> variable matches 1.. run tellraw @s [{"text":"[Jail] ","color":"dark_red","clickEvent":{"action":"run_command","value":"/trigger spawn set -101"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Jail Area","bold":true,"color":"gold"}," in spectator mode"]}},{"selector":"@p[tag=selected_player]","color":"red"},{"text":" is already jailed!","color":"red"}]
 
 # Do Jail
 execute if score <returned> variable matches 0 as @p[tag=selected_player] run function pandamium:misc/get_jailed
-execute if score <returned> variable matches 0 run scoreboard players operation @p[tag=selected_player] jailed = <jail_type> variable
 
 execute if score <returned> variable matches 0 run scoreboard players add @s silent_punishments 0
 execute if score <returned> variable matches 0 unless score @s staff_alt matches 1 if score @s silent_punishments matches 0 run tellraw @a [{"text":"[Jail] ","color":"dark_purple","clickEvent":{"action":"run_command","value":"/trigger spawn set -101"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"dark_purple"},{"text":"Jail Area","bold":true,"color":"light_purple"}," in spectator mode"]}},{"selector":"@p[tag=selected_player]","color":"light_purple"}," was jailed by ",{"selector":"@s","color":"light_purple"},"!"]


### PR DESCRIPTION
- Jail trigger should now work consistently
- Switching players between jails should now work again
- `/trigger gift` will no longer create particles at staff who are in spectator mode or hidden