### PR TITLE
Added enderman_farm trigger

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -1,6 +1,7 @@
 # run AT @s
 
 execute if score @s spawn = @s spawn unless score @s spawn matches 0 run function pandamium:triggers/spawn
+execute if score @s enderman_farm = @s enderman_farm unless score @s enderman_farm matches 0 run function pandamium:triggers/enderman_farm
 execute if score @s respawn matches 1.. run function pandamium:triggers/respawn
 execute if score @s playtime = @s playtime unless score @s playtime matches 0 run function pandamium:triggers/playtime
 execute if score @s discord matches 1.. run function pandamium:triggers/discord

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/monthly_reset.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/monthly_reset.mcfunction
@@ -1,6 +1,11 @@
 # Gets run at the begining of every month
 
-tellraw @a [{"text":"[Info]","color":"blue"},{"text":" The monthly leaderboards have been reset!","color":"green"}]
 scoreboard players reset * monthly_playtime_ticks
 scoreboard players reset * monthly_playtime_ticks
 scoreboard players reset * monthly_votes
+
+scoreboard players reset <enderman_farm_x> global
+scoreboard players reset <enderman_farm_y> global
+scoreboard players reset <enderman_farm_z> global
+
+tellraw @a [{"text":"[Info]","color":"blue"},{"text":" The monthly leaderboards and enderman farm coordinates have been reset!","color":"green"}]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/main.mcfunction
@@ -1,0 +1,3 @@
+execute if data storage pandamium:queue queue[0] run function pandamium:misc/queue/iter
+execute if data storage pandamium:queue carry[0] run data modify storage pandamium:queue queue append from storage pandamium:queue carry[]
+execute if data storage pandamium:queue carry[0] run data remove storage pandamium:queue carry[]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/set_enderman_farm_coordinates.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/set_enderman_farm_coordinates.mcfunction
@@ -1,0 +1,11 @@
+# Since these players insist on exhausting the afk rules to farm playtime, they now get their own
+# specific playtime behaviour that will only count if they have moved within the last 15 seconds :D
+
+data modify storage pandamium:temp NBT set from entity @s
+execute store result score <enderman_farm_x> global run data get storage pandamium:temp NBT.Pos[0]
+execute store result score <enderman_farm_y> global run data get storage pandamium:temp NBT.Pos[1]
+execute store result score <enderman_farm_z> global run data get storage pandamium:temp NBT.Pos[2]
+
+execute at @s if block ~ ~-1 ~ air run setblock ~ ~-1 ~ obsidian
+
+tellraw @s [{"text":"[Warp]","color":"dark_green"},[{"text":" The ","color":"green"},{"text":"enderman farm","italic":true}," warp has been set at your location!"]]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/warp/enderman_farm.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/warp/enderman_farm.mcfunction
@@ -1,0 +1,8 @@
+# only run IF score <enderman_farm_x> global = <enderman_farm_x> global
+
+scoreboard players operation <tp_x> variable = <enderman_farm_x> global
+scoreboard players operation <tp_y> variable = <enderman_farm_y> global
+scoreboard players operation <tp_z> variable = <enderman_farm_z> global
+scoreboard players set <tp_d> variable 1
+
+function pandamium:misc/teleport/to_scores/main

--- a/snapshot_pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -20,6 +20,7 @@ scoreboard players reset @s selected_player
 
 # Triggers
 scoreboard players enable @s spawn
+scoreboard players enable @s enderman_farm
 scoreboard players enable @s parkour
 scoreboard players enable @s respawn
 scoreboard players enable @s options
@@ -35,8 +36,8 @@ scoreboard players enable @s homes
 scoreboard players enable @s clear
 scoreboard players enable @s world_info
 scoreboard players enable @s gift
-
 scoreboard players enable @s save_mob.spawn
+
 execute if score @s parkour.checkpoint matches 0.. run scoreboard players enable @s parkour.quit
 execute if score @s parkour.checkpoint matches 0.. run scoreboard players enable @s parkour.restart
 

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -23,6 +23,7 @@ scoreboard objectives setdisplay sidebar sidebar
 scoreboard objectives add save_mob.spawn trigger
 
 scoreboard objectives add spawn trigger
+scoreboard objectives add enderman_farm trigger
 scoreboard objectives add respawn trigger
 scoreboard objectives add options trigger
 
@@ -200,6 +201,7 @@ scoreboard objectives add temp_1 dummy
 scoreboard players reset * variable
 
 scoreboard players reset * spawn
+scoreboard players reset * enderman_farm
 scoreboard players reset * respawn
 scoreboard players reset * vote
 scoreboard players reset * vote_shop

--- a/snapshot_pandamium_datapack/data/pandamium/functions/triggers/enderman_farm.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/triggers/enderman_farm.mcfunction
@@ -1,0 +1,14 @@
+scoreboard players set <returned> variable 0
+
+execute if score <returned> variable matches 0 store success score <returned> variable if score @s enderman_farm matches -1 if score @s staff_perms matches 1.. unless score @s in_dimension matches 1 run tellraw @s [{"text":"[Warp]","color":"dark_red"},[{"text":" The ","color":"red"},{"text":"Enderman Farm","italic":true}," warp can only be created in The End!"]]
+execute if score <returned> variable matches 0 store success score <returned> variable if score @s enderman_farm matches -1 if score @s staff_perms matches 1.. run function pandamium:misc/set_enderman_farm_coordinates
+
+execute if score <returned> variable matches 0 store success score <returned> variable unless score @s enderman_farm matches 1.. run tellraw @s [{"text":"[Warp]","color":"dark_red"},{"text":" That is not a valid option!","color":"red"}]
+
+execute if score <returned> variable matches 0 store success score <returned> variable if score <enderman_farm_x> global = <enderman_farm_x> global run function pandamium:misc/teleport/warp/enderman_farm
+execute if score <returned> variable matches 0 store success score <returned> variable if score @s staff_perms matches 1.. if score @s in_dimension matches 1 run tellraw @s [{"text":"[Warp]","color":"gold"},[{"text":" The ","color":"yellow"},{"text":"Enderman Farm","italic":true}," warp has not been created yet! Click ",{"text":"[Here]","bold":true,"color":"dark_green","clickEvent":{"action":"run_command","value":"/trigger enderman_farm set -1"},"hoverEvent":{"action":"show_text","value":{"text":"Click to set the Enderman Farm warp at your location","color":"dark_green"}}}," to create it at your location."]]
+execute if score <returned> variable matches 0 store success score <returned> variable if score @s staff_perms matches 1.. run tellraw @s [{"text":"[Warp]","color":"dark_red"},[{"text":" The ","color":"red"},{"text":"Enderman Farm","italic":true}," warp has not been created yet! Go to The End to create it."]]
+execute if score <returned> variable matches 0 store success score <returned> variable run tellraw @s [{"text":"[Warp]","color":"dark_red"},[{"text":" The ","color":"red"},{"text":"Enderman Farm","italic":true}," warp has not been created yet!"]]
+
+scoreboard players reset @s enderman_farm
+scoreboard players enable @s enderman_farm


### PR DESCRIPTION
- Staff can run `/trigger enderman_farm` to set the coordinates of the enderman farm warp
- Running `/trigger enderman_farm` will teleport you to those coordinates
- It gets reset at the beginning of each month