### PR TITLE
added Custom Dragon Fight

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_entity.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_entity.mcfunction
@@ -3,4 +3,6 @@ execute store result storage pandamium:temp Health float 0.01 run data get entit
 
 execute store result score <max_health> variable run attribute @s generic.max_health get
 
-title @p[tag=player] actionbar ["",{"selector":"@s"}," ",{"nbt":"Health","storage":"pandamium:temp","color":"yellow"},"/",{"score":{"name":"<max_health>","objective":"variable"},"color":"yellow"}]
+scoreboard players set <hurt_shielded_entity> variable 0
+execute store success score <hurt_shielded_entity> variable if entity @s[type=phantom,team=dragon_fight] if data entity @s Passengers run title @p[tag=player] actionbar [{"selector":"@s"},{"text":" is shielded by its crystal","color":"yellow"}]
+execute if score <hurt_shielded_entity> variable matches 0 run title @p[tag=player] actionbar ["",{"selector":"@s"}," ",{"nbt":"Health","storage":"pandamium:temp","color":"yellow"},"/",{"score":{"name":"<max_health>","objective":"variable"},"color":"yellow"}]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/dragon_fight/loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/dragon_fight/loop.mcfunction
@@ -1,0 +1,6 @@
+execute in the_end run team join dragon_fight @e[type=enderman,x=0]
+execute in the_end as @e[type=phantom,team=dragon_fight] if data entity @s Passengers run effect give @s resistance 1 5 true
+
+execute in the_end if entity @e[type=ender_dragon,x=0] run schedule function pandamium:misc/dragon_fight/loop 5t
+
+

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/dragon_fight/start.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/dragon_fight/start.mcfunction
@@ -1,0 +1,23 @@
+team join dragon_fight @e[type=ender_dragon]
+
+execute in the_end run summon phantom 0 90 0 {Size:8,Passengers:[{id:end_crystal,ShowBottom:false,Invulnerable:true,Tags:['dragon_fight']}],Attributes:[{Base:120d,Name:'minecraft:generic.max_health'}],Health:120,CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon phantom 0 90 0 {Size:8,Passengers:[{id:end_crystal,ShowBottom:false,Invulnerable:true,Tags:['dragon_fight']}],Attributes:[{Base:120d,Name:'minecraft:generic.max_health'}],Health:120,CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon phantom 0 90 0 {Size:8,Passengers:[{id:end_crystal,ShowBottom:false,Invulnerable:true,Tags:['dragon_fight']}],Attributes:[{Base:120d,Name:'minecraft:generic.max_health'}],Health:120,CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon phantom 0 90 0 {Size:8,Passengers:[{id:end_crystal,ShowBottom:false,Invulnerable:true,Tags:['dragon_fight']}],Attributes:[{Base:120d,Name:'minecraft:generic.max_health'}],Health:120,CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon phantom 0 90 0 {Size:8,Passengers:[{id:end_crystal,ShowBottom:false,Invulnerable:true,Tags:['dragon_fight']}],Attributes:[{Base:120d,Name:'minecraft:generic.max_health'}],Health:120,CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon phantom 0 90 0 {Size:8,Passengers:[{id:end_crystal,ShowBottom:false,Invulnerable:true,Tags:['dragon_fight']}],Attributes:[{Base:120d,Name:'minecraft:generic.max_health'}],Health:120,CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end run summon warden 0 64 0 {Brain:{memories:{"minecraft:dig_cooldown":{ttl:1200L,value:{}},"minecraft:is_emerging":{ttl:134L,value:{}}}},CustomName:'{"text":"Dragon\'s Henchman"}',Tags:['dragon_fight'],Team:'dragon_fight'}
+execute in the_end positioned 0 64 0 run spreadplayers 0 0 30 50 false @e[type=warden,distance=..100]
+execute in the_end positioned 0 64 0 at @e[type=warden,distance=..100] run placefeature sculk_patch_deep_dark
+
+function pandamium:misc/dragon_fight/loop

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -339,6 +339,9 @@ team join gray_color Mobs:
 team join gray_color Items:
 team join gray_color MobCap:
 
+team add dragon_fight
+team modify dragon_fight friendlyFire false
+
 
 execute in pandamium:staff_world run forceload add -1 -1 0 0
 execute in pandamium:staff_world unless block 6 64 3 oak_wall_sign run setblock 6 64 3 oak_wall_sign[facing=west]{Text2:'{"text":"[Restore Lore]","bold":true,"clickEvent":{"action":"run_command","value":"/function pandamium:misc/jail_items/restore_lore/main"}}'}


### PR DESCRIPTION
- Running `/function pandamium:misc/dragon_fight/start` while there dragon has spawned will start the custom fight
- When the fight starts:
  - 6 large phantoms with end crystals on their backs will spawn at the island's centre
  - 10 wardens will spawn randomly on the centre island
- The phantoms' crystals must be destroyed before they can be hurt