### PR TITLE
changed SAY command chat style

### DIFF
--- a/snapshot_pandamium_datapack/data/minecraft/chat_type/say_command.json
+++ b/snapshot_pandamium_datapack/data/minecraft/chat_type/say_command.json
@@ -1,0 +1,24 @@
+{
+	"chat": {
+		"decoration": {
+			"translation_key": "§9[Info]§r %s",
+			"parameters": [
+				"content"
+			],
+			"style": {
+				"color": "green"
+			}
+		}
+	},
+	"narration": {
+		"decoration": {
+			"translation_key": "chat.type.text.narrate",
+			"parameters": [
+				"sender",
+				"content"
+			],
+			"style": {}
+		},
+		"priority": "chat"
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/functions/first_join.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/first_join.mcfunction
@@ -3,9 +3,7 @@ function pandamium:misc/give_guidebook
 
 playsound entity.experience_orb.pickup master @a[scores={staff_perms=1..}] ~ ~ ~ 1 2 1
 
-tellraw @a[scores={staff_perms=0}] [{"text":"[Server] ","color":"dark_blue"},[{"text":"Welcome to the server, ","color":"dark_aqua"},{"selector":"@s"},"! Have fun!"]]
-tellraw @a[scores={staff_perms=1..}] [{"text":"[Server] ","color":"dark_blue","clickEvent":{"action":"run_command","value":"trigger spawn set -1"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Spawn","bold":true}]}},[{"text":"Welcome to the server, ","color":"dark_aqua"},{"selector":"@s","clickEvent":{"action":"run_command","value":"trigger spawn set -1"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to teleport to ","color":"yellow"},{"text":"Spawn","bold":true}]}},"! Have fun!"]]
-
-tellraw @s [{"text":"[Server]","color":"dark_blue","clickEvent":{"action":"open_url","value":"http://discord.pandamium.eu"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to join our ","color":"aqua"},{"text":"Discord Server","bold":true}]}},[{"text":" Use the ","color":"green"},{"text":"RTP","color":"aqua"}," at spawn and ",{"text":"read the guidebook","color":"aqua"}," to get started. ",{"text":"Click here to join our Discord Server","color":"aqua"}," for the full rules and announcements about the server!"]]
+say §3Welcome to the server, @s§3! Have fun!§r
+tellraw @s [{"text":"[Info]","color":"blue","clickEvent":{"action":"open_url","value":"http://discord.pandamium.eu"},"hoverEvent":{"action":"show_text","value":[{"text":"Click to join our ","color":"aqua"},{"text":"Discord Server","bold":true}]}},[{"text":" Use the ","color":"green"},{"text":"RTP","color":"aqua"}," at spawn and ",{"text":"read the guidebook","color":"aqua"}," to get started. ",{"text":"Click here to join our Discord Server","color":"aqua"}," for the full rules and announcements about the server!"]]
 
 tellraw @a[scores={staff_perms=1..}] [{"text":"","color":"gray"},{"text":"[Info] ","color":"dark_gray"},{"selector":"@s","color":"gray"},"'s id is ",{"score":{"objective":"id","name":"@s"},"bold":true},"!"]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/monthly_reset.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/monthly_reset.mcfunction
@@ -8,4 +8,4 @@ scoreboard players reset <enderman_farm_x> global
 scoreboard players reset <enderman_farm_y> global
 scoreboard players reset <enderman_farm_z> global
 
-tellraw @a [{"text":"[Info]","color":"blue"},{"text":" The monthly leaderboards and enderman farm coordinates have been reset!","color":"green"}]
+say The monthly leaderboards and enderman farm coordinates have been reset!

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/monthly_reset.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/monthly_reset.mcfunction
@@ -8,4 +8,5 @@ scoreboard players reset <enderman_farm_x> global
 scoreboard players reset <enderman_farm_y> global
 scoreboard players reset <enderman_farm_z> global
 
-say The monthly leaderboards and enderman farm coordinates have been reset!
+# Used §a instead of §r because of a bug with text overflowing onto new lines changing its parent formatting
+say The monthly §bleaderboards§a and §benderman farm coordinates§a have been §breset§a!


### PR DESCRIPTION
- Any time someone uses `/say <message>`, the text will be formatted to look like our generic [Info] messages.
- A player joining for the first time, and the monthly reset messages now both use `/say` so that they appear on the Discord server through the `#snapshot-ingame-chat` channel
e.g.
![image](https://user-images.githubusercontent.com/16517352/169652375-fe89d9c7-af2b-4ba3-874c-f65ca317a0b6.png)
![image](https://user-images.githubusercontent.com/16517352/169652385-23582bfd-6b21-4b7e-81f8-ec9774c8e114.png)
Note:
- The name of the person using `/say` is not sent
- The message will always appear green, but other colours (e.g. `aqua`) can be used with formatting codes (e.g. `§b`)