### PR TITLE
fixed player_info issues

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/player_info/click_events.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/player_info/click_events.mcfunction
@@ -29,7 +29,7 @@ execute if score @s player_info matches -11 run scoreboard players operation @s 
 execute if score @s player_info matches -11 store success score <player_info_returned> variable run function pandamium:triggers/enderchest
 
 execute if score @s player_info matches -12 run scoreboard players operation @s homes = @s selected_player
-execute if score @s player_info matches -12 store success score <player_info_returned> variable run function pandamium:triggers/show_homes
+execute if score @s player_info matches -12 store success score <player_info_returned> variable run function pandamium:triggers/homes
 
 execute if score @s player_info matches -13 run scoreboard players operation @s get_guidebook = @s selected_player
 execute if score @s player_info matches -13 store success score <player_info_returned> variable run function pandamium:triggers/get_guidebook
@@ -58,5 +58,4 @@ execute if score @s player_info matches -21 if score @s staff_perms matches 2.. 
 
 #
 
-execute if score @s player_info matches ..-22 run scoreboard players set <player_info_can_run> variable 0
-execute if score <player_info_can_run> variable matches 0 run tellraw @s [{"text":"[Player Info]","color":"dark_red"},{"text":" That is not a valid option!","color":"red"}]
+execute if score <player_info_returned> variable matches 0 run tellraw @s [{"text":"[Player Info]","color":"dark_red"},{"text":" That is not a valid option!","color":"red"}]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/triggers/player_info.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/triggers/player_info.mcfunction
@@ -3,12 +3,11 @@
 scoreboard players set <player_info_returned> variable 0
 tag @s add player_info_running_trigger
 
-execute if score @s player_info matches 1 run function pandamium:misc/print_nearest_non_staff_player
-execute if score @s player_info matches 1 if score @s selected_player matches 2.. run scoreboard players operation @s player_info = @s selected_player
+execute store success score <player_info_returned> variable if score @s player_info matches 1 unless score @s selected_player matches 2.. run function pandamium:misc/print_nearest_non_staff_player
+execute if score <player_info_returned> variable matches 0 if score @s player_info matches 1 if score @s selected_player matches 2.. run scoreboard players operation @s player_info = @s selected_player
 
-execute if score @s player_info matches -1 run scoreboard players operation @s player_info = @p[scores={staff_perms=0},distance=..200] id
-execute store success score <player_info_returned> variable if score @s player_info matches -1 run tellraw @s [{"text":"[Player Info]","color":"dark_red"},{"text":" Could not find a non-staff player nearby!","color":"red"}]
-#execute if score <player_info_returned> variable matches 0 store success score <player_info_returned> variable if score @s player_info matches ..-2 run tellraw @s [{"text":"[Player Info]","color":"dark_red"},{"text":" That is not a valid option!","color":"red"}]
+execute if score <player_info_returned> variable matches 0 if score @s player_info matches -1 run scoreboard players operation @s player_info = @p[scores={staff_perms=0},distance=..200] id
+execute if score <player_info_returned> variable matches 0 store success score <player_info_returned> variable if score @s player_info matches -1 run tellraw @s [{"text":"[Player Info]","color":"dark_red"},{"text":" Could not find a non-staff player nearby!","color":"red"}]
 
 # Menu
 execute if score <player_info_returned> variable matches 0 if score @s player_info matches 1.. run scoreboard players set <player_info_player_exists> variable 0


### PR DESCRIPTION
- Removed redundant error message when running `/trigger player_info` with no player selected
- Fixed the `[Homes]` button always creating an error message, then running the trigger 5 ticks later