### PR TITLE
Chest-boat dupe patch

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/advancements/run_once/exploit_patch/chest_boat_dupe_patch_warning.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/run_once/exploit_patch/chest_boat_dupe_patch_warning.json
@@ -1,0 +1,17 @@
+{
+	"criteria": {
+		"obtain_chest_boat": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"tag": "chest_boats"
+					}
+				]
+			}
+		}
+	},
+	"rewards": {
+		"function": "pandamium:misc/chest_boat_dupe_patch/print_warning_message"
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -74,5 +74,6 @@ execute as @a[gamemode=spectator] at @s run function pandamium:misc/portal/loop
 function pandamium:misc/particles/main_loop
 
 execute as @e[type=#pandamium:donkey_dupe_mobs,nbt={ChestedHorse:1b}] in pandamium:staff_world run function pandamium:misc/donkey_dupe_patch/drop_items
+execute as @e[type=chest_boat] at @s run function pandamium:misc/chest_boat_dupe_patch/drop_items
 
 schedule function pandamium:main_loop 5t

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/chest_boat_dupe_patch/drop_items.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/chest_boat_dupe_patch/drop_items.mcfunction
@@ -1,0 +1,6 @@
+# run AT @s
+
+summon boat
+data modify entity @e[type=boat,limit=1,sort=nearest,distance=0] {} merge from entity @s
+kill
+summon item ~ ~1 ~ {Item:{id:"minecraft:chest",Count:1b}}

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/chest_boat_dupe_patch/print_warning_message.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/chest_boat_dupe_patch/print_warning_message.mcfunction
@@ -1,0 +1,1 @@
+tellraw @s [{"text":"[Info]","color":"dark_red"},{"text":" Chest boats have been disabled due to a duplication exploit!","color":"red"}]


### PR DESCRIPTION
- When placing a chest boat, it will get replaced with a regular boat and its contents and the chest itself will be dropped as items
- When obtaining a chest boat for the first time, the player will be sent a warning message about chest boats being disabled