### PR TITLE
fixed staff perms error

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/update_teams.mcfunction
@@ -11,7 +11,7 @@ execute if entity @s[team=elder] if score @s votes matches 500.. if score @s pla
 execute if entity @s[team=veteran] if score @s votes matches 2500.. if score @s playtime_ticks matches 180000000.. run team join elite
 
 # Staff Perms
-scoreboard players reset @s staff_perms
+scoreboard players set @s staff_perms 0
 scoreboard players set @s[team=helper] staff_perms 1
 scoreboard players set @s[team=mod] staff_perms 2
 scoreboard players set @s[team=srmod] staff_perms 3


### PR DESCRIPTION
Online non-staff players should have a `staff_perms` score of `0`, not `null`