### PR TITLE
TNT handling parity change

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -1,4 +1,4 @@
-kill @e[type=tnt]
+execute as @e[type=#pandamium:tnt] at @s run function pandamium:misc/defuse_tnt
 
 function pandamium:misc/update_dimension
 

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/defuse_tnt.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/defuse_tnt.mcfunction
@@ -1,0 +1,3 @@
+particle cloud ~ ~0.6 ~ 0.125 0.125 0.125 0 5
+execute if entity @s[type=tnt_minecart] run summon minecart
+kill

--- a/snapshot_pandamium_datapack/data/pandamium/tags/entity_types/tnt.json
+++ b/snapshot_pandamium_datapack/data/pandamium/tags/entity_types/tnt.json
@@ -1,0 +1,6 @@
+{
+	"values": [
+		"tnt",
+		"tnt_minecart"
+	]
+}


### PR DESCRIPTION
- TNT and TNT Minecarts are both killed and cloud particles are displayed
- TNT Minecarts are replaced with a regular minecart, so just the TNT itself is removed, not the whole thing