### PR TITLE
Added Legacy Advancements

### DIFF
--- a/release_pandamium_datapack/data/minecraft/advancements/end/levitate.json
+++ b/release_pandamium_datapack/data/minecraft/advancements/end/levitate.json
@@ -1,0 +1,47 @@
+{
+	"display": {
+		"icon": {
+			"item": "shulker_shell"
+		},
+		"title": {
+			"translate": "advancements.end.levitate.title"
+		},
+		"description": {
+			"translate": "advancements.end.levitate.description"
+		},
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"parent": "end/find_end_city",
+	"criteria": {
+		"levitated": {
+			"trigger": "levitation",
+			"conditions": {
+				"player": [
+					{
+						"condition": "inverted",
+						"term": {
+							"condition": "reference",
+							"name": "pandamium:in_spawn"
+						}
+					}
+				],
+				"distance": {
+					"y": {
+						"min": 50
+					}
+				}
+			}
+		}
+	},
+	"requirements": [
+		[
+			"levitated"
+		]
+	],
+	"rewards": {
+		"experience": 50
+	}
+}

--- a/release_pandamium_datapack/data/minecraft/advancements/husbandry/balanced_diet.json
+++ b/release_pandamium_datapack/data/minecraft/advancements/husbandry/balanced_diet.json
@@ -1,0 +1,544 @@
+{
+	"parent": "pandamium:minecraft/husbandry/obtain_cake",
+	"display": {
+		"icon": {
+			"item": "apple"
+		},
+		"title": {
+			"translate": "advancements.husbandry.balanced_diet.title"
+		},
+		"description": {
+			"translate": "advancements.husbandry.balanced_diet.description"
+		},
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"apple": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"apple"
+					]
+				}
+			}
+		},
+		"baked_potato": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"baked_potato"
+					]
+				}
+			}
+		},
+		"beef": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"beef"
+					]
+				}
+			}
+		},
+		"beetroot": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"beetroot"
+					]
+				}
+			}
+		},
+		"beetroot_soup": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"beetroot_soup"
+					]
+				}
+			}
+		},
+		"bread": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"bread"
+					]
+				}
+			}
+		},
+		"carrot": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"carrot"
+					]
+				}
+			}
+		},
+		"chicken": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"chicken"
+					]
+				}
+			}
+		},
+		"chorus_fruit": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"chorus_fruit"
+					]
+				}
+			}
+		},
+		"cod": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cod"
+					]
+				}
+			}
+		},
+		"cooked_beef": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_beef"
+					]
+				}
+			}
+		},
+		"cooked_chicken": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_chicken"
+					]
+				}
+			}
+		},
+		"cooked_cod": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_cod"
+					]
+				}
+			}
+		},
+		"cooked_mutton": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_mutton"
+					]
+				}
+			}
+		},
+		"cooked_porkchop": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_porkchop"
+					]
+				}
+			}
+		},
+		"cooked_rabbit": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_rabbit"
+					]
+				}
+			}
+		},
+		"cooked_salmon": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_salmon"
+					]
+				}
+			}
+		},
+		"cookie": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cookie"
+					]
+				}
+			}
+		},
+		"dried_kelp": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"dried_kelp"
+					]
+				}
+			}
+		},
+		"enchanted_golden_apple": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"enchanted_golden_apple"
+					]
+				}
+			}
+		},
+		"glow_berries": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"glow_berries"
+					]
+				}
+			}
+		},
+		"golden_apple": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"golden_apple"
+					]
+				}
+			}
+		},
+		"golden_carrot": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"golden_carrot"
+					]
+				}
+			}
+		},
+		"honey_bottle": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"honey_bottle"
+					]
+				}
+			}
+		},
+		"melon_slice": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"melon_slice"
+					]
+				}
+			}
+		},
+		"mushroom_stew": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"mushroom_stew"
+					]
+				}
+			}
+		},
+		"mutton": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"mutton"
+					]
+				}
+			}
+		},
+		"poisonous_potato": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"poisonous_potato"
+					]
+				}
+			}
+		},
+		"porkchop": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"porkchop"
+					]
+				}
+			}
+		},
+		"potato": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"potato"
+					]
+				}
+			}
+		},
+		"pufferfish": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"pufferfish"
+					]
+				}
+			}
+		},
+		"pumpkin_pie": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"pumpkin_pie"
+					]
+				}
+			}
+		},
+		"rabbit": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"rabbit"
+					]
+				}
+			}
+		},
+		"rabbit_stew": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"rabbit_stew"
+					]
+				}
+			}
+		},
+		"rotten_flesh": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"rotten_flesh"
+					]
+				}
+			}
+		},
+		"salmon": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"salmon"
+					]
+				}
+			}
+		},
+		"spider_eye": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"spider_eye"
+					]
+				}
+			}
+		},
+		"suspicious_stew": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"suspicious_stew"
+					]
+				}
+			}
+		},
+		"sweet_berries": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"sweet_berries"
+					]
+				}
+			}
+		},
+		"tropical_fish": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"tropical_fish"
+					]
+				}
+			}
+		}
+	},
+	"requirements": [
+		[
+			"apple"
+		],
+		[
+			"mushroom_stew"
+		],
+		[
+			"bread"
+		],
+		[
+			"porkchop"
+		],
+		[
+			"cooked_porkchop"
+		],
+		[
+			"golden_apple"
+		],
+		[
+			"enchanted_golden_apple"
+		],
+		[
+			"cod"
+		],
+		[
+			"salmon"
+		],
+		[
+			"tropical_fish"
+		],
+		[
+			"pufferfish"
+		],
+		[
+			"cooked_cod"
+		],
+		[
+			"cooked_salmon"
+		],
+		[
+			"cookie"
+		],
+		[
+			"melon_slice"
+		],
+		[
+			"beef"
+		],
+		[
+			"cooked_beef"
+		],
+		[
+			"chicken"
+		],
+		[
+			"cooked_chicken"
+		],
+		[
+			"rotten_flesh"
+		],
+		[
+			"spider_eye"
+		],
+		[
+			"carrot"
+		],
+		[
+			"potato"
+		],
+		[
+			"baked_potato"
+		],
+		[
+			"poisonous_potato"
+		],
+		[
+			"golden_carrot"
+		],
+		[
+			"pumpkin_pie"
+		],
+		[
+			"rabbit"
+		],
+		[
+			"cooked_rabbit"
+		],
+		[
+			"rabbit_stew"
+		],
+		[
+			"mutton"
+		],
+		[
+			"cooked_mutton"
+		],
+		[
+			"chorus_fruit"
+		],
+		[
+			"beetroot"
+		],
+		[
+			"beetroot_soup"
+		],
+		[
+			"dried_kelp"
+		],
+		[
+			"suspicious_stew"
+		],
+		[
+			"sweet_berries"
+		],
+		[
+			"honey_bottle"
+		],
+		[
+			"glow_berries"
+		]
+	],
+	"rewards": {
+		"experience": 100
+	}
+}

--- a/release_pandamium_datapack/data/minecraft/advancements/husbandry/obtain_netherite_hoe.json
+++ b/release_pandamium_datapack/data/minecraft/advancements/husbandry/obtain_netherite_hoe.json
@@ -1,0 +1,39 @@
+{
+	"display": {
+		"icon": {
+			"item": "netherite_hoe",
+			"nbt": "{Damage:0}"
+		},
+		"title": {
+			"translate": "advancements.husbandry.netherite_hoe.title"
+		},
+		"description": "Use a Netherite Ingot to upgrade a Hoe",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"parent": "husbandry/plant_seed",
+	"criteria": {
+		"netherite_hoe": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": [
+							"netherite_hoe"
+						]
+					}
+				]
+			}
+		}
+	},
+	"requirements": [
+		[
+			"netherite_hoe"
+		]
+	],
+	"rewards": {
+		"experience": 100
+	}
+}

--- a/release_pandamium_datapack/data/minecraft/advancements/story/enter_the_nether.json
+++ b/release_pandamium_datapack/data/minecraft/advancements/story/enter_the_nether.json
@@ -1,0 +1,40 @@
+{
+	"display": {
+		"icon": {
+			"item": "flint_and_steel"
+		},
+		"title": {
+			"translate": "advancements.story.enter_the_nether.title"
+		},
+		"description": {
+			"translate": "advancements.story.enter_the_nether.description"
+		},
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"parent": "story/form_obsidian",
+	"criteria": {
+		"entered_nether": {
+			"trigger": "changed_dimension",
+			"conditions": {
+				"player": [
+					{
+						"condition": "inverted",
+						"term": {
+							"condition": "reference",
+							"name": "pandamium:in_spawn"
+						}
+					}
+				],
+				"to": "the_nether"
+			}
+		}
+	},
+	"requirements": [
+		[
+			"entered_nether"
+		]
+	]
+}

--- a/release_pandamium_datapack/data/minecraft/advancements/story/mine_stone.json
+++ b/release_pandamium_datapack/data/minecraft/advancements/story/mine_stone.json
@@ -1,0 +1,35 @@
+{
+	"display": {
+		"icon": {
+			"item": "wooden_pickaxe"
+		},
+		"title": {
+			"translate": "advancements.story.mine_stone.title"
+		},
+		"description": {
+			"translate": "advancements.story.mine_stone.description"
+		},
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"parent": "pandamium:minecraft/story/obtain_log",
+	"criteria": {
+		"get_stone": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"tag": "stone_tool_materials"
+					}
+				]
+			}
+		}
+	},
+	"requirements": [
+		[
+			"get_stone"
+		]
+	]
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/detect/place_wet_sponge.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/detect/place_wet_sponge.json
@@ -1,0 +1,23 @@
+{
+	"criteria": {
+		"place_wet_sponge": {
+			"trigger": "tick",
+			"conditions": {
+				"player": [
+					{
+						"condition": "entity_scores",
+						"entity": "this",
+						"scores": {
+							"detect.use.wet_sponge": {
+								"min": 1
+							}
+						}
+					}
+				]
+			}
+		}
+	},
+	"rewards": {
+		"function": "pandamium:misc/detect/place_wet_sponge"
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/detect/tie_dye_outfit.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/detect/tie_dye_outfit.json
@@ -1,0 +1,76 @@
+{
+	"criteria": {
+		"wear_leather_armor": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"player": [
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"head": {
+									"items": [
+										"leather_helmet"
+									]
+								}
+							}
+						}
+					},
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"chest": {
+									"items": [
+										"leather_chestplate"
+									]
+								}
+							}
+						}
+					},
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"legs": {
+									"items": [
+										"leather_leggings"
+									]
+								}
+							}
+						}
+					},
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"feet": {
+									"items": [
+										"leather_boots"
+									]
+								}
+							}
+						}
+					}
+				],
+				"items": [
+					{
+						"items": [
+							"leather_boots",
+							"leather_leggings",
+							"leather_chestplate",
+							"leather_helmet"
+						]
+					}
+				]
+			}
+		}
+	},
+	"rewards": {
+		"function": "pandamium:misc/detect/tie_dye_outfit"
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/do_a_barrel_roll.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/do_a_barrel_roll.json
@@ -1,0 +1,18 @@
+{
+	"display": {
+		"icon": {
+			"item": "trident"
+		},
+		"title": "Do A Barrel Roll!",
+		"description": "Use the Riptide enchantment to give yourself a boost",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "adventure/throw_trident",
+	"criteria": {
+		"use_trident": {
+			"trigger": "impossible"
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/kill_an_elder_guardian.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/kill_an_elder_guardian.json
@@ -1,0 +1,23 @@
+{
+	"display": {
+		"icon": {
+			"item": "wet_sponge"
+		},
+		"title": "The Deep End",
+		"description": "Defeat an Elder Guardian",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "adventure/kill_a_mob",
+	"criteria": {
+		"kill_elder_guardian": {
+			"trigger": "player_killed_entity",
+			"conditions": {
+				"entity": {
+					"type": "elder_guardian"
+				}
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/overkill.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/overkill.json
@@ -1,0 +1,25 @@
+{
+	"parent": "adventure/kill_a_mob",
+	"display": {
+		"icon": {
+			"item": "netherite_sword"
+		},
+		"title": "Overkill",
+		"description": "Deal nine hearts of damage in a single hit.",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"deal_9_hearts_of_damage": {
+			"trigger": "player_hurt_entity",
+			"conditions": {
+				"damage": {
+					"dealt": {
+						"min": 18
+					}
+				}
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/end/break_elytra_in_sky.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/end/break_elytra_in_sky.json
@@ -4,7 +4,7 @@
 			"item": "elytra",
 			"nbt": "{Damage:432}"
 		},
-		"title": "Houston, We Have A Problem",
+		"title": "Minecraft, We Have A Problem",
 		"description": "Have your elytra break while above y-level 600",
 		"frame": "challenge",
 		"show_toast": true,

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/break_netherrite_hoe.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/break_netherrite_hoe.json
@@ -1,0 +1,30 @@
+{
+	"parent": "husbandry/obtain_netherite_hoe",
+	"display": {
+		"icon": {
+			"item": "netherite_hoe",
+			"nbt": "{Damage:2031}"
+		},
+		"title": "Life Choices",
+		"description": "Completely use up a netherite hoe, and then reevaluate your life choices",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"break_hoe": {
+			"trigger": "item_durability_changed",
+			"conditions": {
+				"durability": 0,
+				"item": {
+					"items": [
+						"netherite_hoe"
+					]
+				}
+			}
+		}
+	},
+	"rewards": {
+		"experience": 100
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_cake.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_cake.json
@@ -1,0 +1,27 @@
+{
+	"display": {
+		"icon": {
+			"item": "cake"
+		},
+		"title": "The Lie",
+		"description": "Bake a cake using: wheat, sugar, milk, and eggs",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "husbandry/plant_seed",
+	"criteria": {
+		"obtain_cake": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": [
+							"cake"
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_leather.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_leather.json
@@ -1,0 +1,27 @@
+{
+	"parent": "husbandry/root",
+	"display": {
+		"icon": {
+			"item": "leather"
+		},
+		"title": "Cow Tipper",
+		"description": "Harvest some leather",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"obtain_leather": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": [
+							"leather"
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/tie_dye_outfit.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/tie_dye_outfit.json
@@ -1,0 +1,19 @@
+{
+	"parent": "pandamium:minecraft/husbandry/obtain_leather",
+	"display": {
+		"icon": {
+			"item": "leather_helmet",
+			"nbt": "{display:{color:13009364}}"
+		},
+		"title": "Tie Dye Outfit",
+		"description": "Uniquely dye and wear 4 mismatched pieces of leather armor",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"wear_tie_dyed_armour": {
+			"trigger": "impossible"
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/nether/dry_spell.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/nether/dry_spell.json
@@ -1,0 +1,18 @@
+{
+	"display": {
+		"icon": {
+			"item": "sponge"
+		},
+		"title": "Dry Spell",
+		"description": "Dry a sponge with the heat of the Nether",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "nether/root",
+	"criteria": {
+		"place_sponge_in_the_nether": {
+			"trigger": "impossible"
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/nether/stayin_frosty.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/nether/stayin_frosty.json
@@ -1,0 +1,27 @@
+{
+	"display": {
+		"icon": {
+			"item": "potion",
+			"nbt": "{Potion:\"fire_resistance\"}"
+		},
+		"title": "Stayin' Frosty",
+		"description": "Swim in lava while having the Fire Resistance effect",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "nether/brew_potion",
+	"criteria": {
+		"swim_in_lava": {
+			"trigger": "enter_block",
+			"conditions": {
+				"player": {
+					"effects": {
+						"fire_resistance": {}
+					}
+				},
+				"block": "lava"
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/story/diamonds_to_you.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/story/diamonds_to_you.json
@@ -1,0 +1,33 @@
+{
+	"display": {
+		"icon": {
+			"item": "diamond"
+		},
+		"title": "Diamonds to You!",
+		"description": "Throw diamonds to another player",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "story/mine_diamond",
+	"criteria": {
+		"throw_diamond_to_a_player": {
+			"trigger": "thrown_item_picked_up_by_entity",
+			"conditions": {
+				"entity": {
+					"type": "player",
+					"distance": {
+						"absolute": {
+							"min": 0.01
+						}
+					}
+				},
+				"item": {
+					"items": [
+						"diamond"
+					]
+				}
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/story/obtain_log.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/story/obtain_log.json
@@ -1,0 +1,25 @@
+{
+	"display": {
+		"icon": {
+			"item": "oak_log"
+		},
+		"title": "Getting Wood",
+		"description": "Punch a tree until a block of wood pops out",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": false
+	},
+	"parent": "story/root",
+	"criteria": {
+		"obtain_log": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"tag": "logs"
+					}
+				]
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/advancements/minecraft/story/on_a_rail.json
+++ b/release_pandamium_datapack/data/pandamium/advancements/minecraft/story/on_a_rail.json
@@ -1,0 +1,31 @@
+{
+	"parent": "minecraft:story/smelt_iron",
+	"display": {
+		"icon": {
+			"item": "rail"
+		},
+		"title": "On A Rail",
+		"description": "Travel at least 500m while in a minecart",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"get_stone": {
+			"trigger": "location",
+			"conditions": {
+				"player": [
+					{
+						"condition": "entity_scores",
+						"entity": "this",
+						"scores": {
+							"detect.advancement.on_a_rail": {
+								"min": 50000
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -11,6 +11,10 @@ execute as @a[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024] at @s run function pan
 execute as @a[predicate=pandamium:in_spawn] run function pandamium:misc/spawn_effects
 tp @e[x=-512,y=-64,z=-512,dx=1024,dy=384,dz=1024,type=#pandamium:remove_at_spawn,tag=!spawn_protected] 0 -1000 0
 
+# 
+scoreboard players reset @a[predicate=!pandamium:riding_minecart] detect.advancement.on_a_rail
+
+# Loops
 function pandamium:misc/map_specific/loop
 
 schedule function pandamium:main_loop 5t

--- a/release_pandamium_datapack/data/pandamium/functions/misc/detect/place_wet_sponge.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/misc/detect/place_wet_sponge.mcfunction
@@ -1,0 +1,4 @@
+execute if predicate pandamium:in_dimension/the_nether run advancement grant @s only pandamium:minecraft/nether/dry_spell
+
+scoreboard players reset @s detect.use.wet_sponge
+advancement revoke @s only pandamium:detect/place_wet_sponge

--- a/release_pandamium_datapack/data/pandamium/functions/misc/detect/tie_dye_outfit.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/misc/detect/tie_dye_outfit.mcfunction
@@ -1,0 +1,13 @@
+data modify storage pandamium:temp NBT set from entity @s
+
+scoreboard players set <all_dyed> variable 0
+execute store success score <all_dyed> variable if data storage pandamium:temp NBT.Inventory[{Slot:100b}].tag.display.color if data storage pandamium:temp NBT.Inventory[{Slot:101b}].tag.display.color if data storage pandamium:temp NBT.Inventory[{Slot:102b}].tag.display.color if data storage pandamium:temp NBT.Inventory[{Slot:103b}].tag.display.color
+
+execute if score <all_dyed> variable matches 1 store result score <boots_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:100b}].tag.display.color
+execute if score <all_dyed> variable matches 1 store result score <leggings_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:101b}].tag.display.color
+execute if score <all_dyed> variable matches 1 store result score <chestplate_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:102b}].tag.display.color
+execute if score <all_dyed> variable matches 1 store result score <helmet_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:103b}].tag.display.color
+
+execute if score <all_dyed> variable matches 1 unless score <boots_color> variable = <leggings_color> variable unless score <boots_color> variable = <chestplate_color> variable unless score <boots_color> variable = <helmet_color> variable unless score <leggings_color> variable = <chestplate_color> variable unless score <leggings_color> variable = <helmet_color> variable unless score <chestplate_color> variable = <helmet_color> variable run advancement grant @s only pandamium:minecraft/husbandry/tie_dye_outfit
+
+advancement revoke @s only pandamium:detect/tie_dye_outfit

--- a/release_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident.mcfunction
@@ -1,8 +1,6 @@
-execute store success score <has_advancement> variable if entity @s[advancements={pandamium:pandamium/mob_heads/blue_shell=true}]
-execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp NBT set from entity @s
-execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp HeadItem set value {}
-execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp HeadItem set from storage pandamium:temp NBT.Inventory[{Slot:103b}]
-execute if score <has_advancement> variable matches 0 if data storage pandamium:temp HeadItem{id:'minecraft:player_head',tag:{SkullOwner:{Name:"§lTurtle"}}} if data storage pandamium:temp NBT.SelectedItem{id:'minecraft:trident'}.tag.Enchantments[{id:'minecraft:riptide'}] run advancement grant @s only pandamium:pandamium/mob_heads/blue_shell
+execute unless entity @s[advancements={pandamium:minecraft/adventure/do_a_barrel_roll=true,pandamium:pandamium/mob_heads/blue_shell=true}] run function pandamium:misc/detect/use_trident/check_advancements
+
+execute if score @s parkour.checkpoint matches 0.. run advancement grant @s only pandamium:detect/parkour/cheat
 
 scoreboard players reset @s detect.use.trident
 advancement revoke @s only pandamium:detect/use_trident

--- a/release_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident/check_advancements.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident/check_advancements.mcfunction
@@ -1,0 +1,8 @@
+data modify storage pandamium:temp NBT set from entity @s
+execute store success score <has_riptide> variable if data storage pandamium:temp NBT.SelectedItem{id:'minecraft:trident'}.tag.Enchantments[{id:'minecraft:riptide'}]
+
+execute if score <has_riptide> variable matches 1 run advancement grant @s only pandamium:minecraft/adventure/do_a_barrel_roll
+
+data modify storage pandamium:temp HeadItem set value {}
+data modify storage pandamium:temp HeadItem set from storage pandamium:temp NBT.Inventory[{Slot:103b}]
+execute if data storage pandamium:temp HeadItem{id:'minecraft:player_head',tag:{SkullOwner:{Name:"§lTurtle"}}} if score <has_riptide> variable matches 1 run advancement grant @s only pandamium:pandamium/mob_heads/blue_shell

--- a/release_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/release_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -6,15 +6,19 @@ scoreboard objectives add gameplay_perms dummy
 
 execute unless score <next_id> global matches 2.. run scoreboard players set <next_id> variable 2
 
-scoreboard objectives add detect.leave_game custom:leave_game
-scoreboard objectives add detect.use.trident used:trident
-scoreboard objectives add detect.aviate custom:aviate_one_cm
-
+# Triggers
 scoreboard objectives add item_font trigger
 scoreboard objectives add sign_font trigger
 scoreboard objectives add world_info trigger
 
-# Reset Scoreboards
+# Detection
+scoreboard objectives add detect.leave_game custom:leave_game
+scoreboard objectives add detect.use.trident used:trident
+scoreboard objectives add detect.use.wet_sponge used:wet_sponge
+scoreboard objectives add detect.aviate custom:aviate_one_cm
+scoreboard objectives add detect.advancement.on_a_rail custom:minecart_one_cm
+
+# Reset Volatile Scoreboards
 scoreboard players reset * detect.leave_game
 scoreboard players reset * detect.use.trident
 scoreboard players reset * detect.aviate
@@ -23,8 +27,10 @@ scoreboard players reset * item_font
 scoreboard players reset * sign_font
 scoreboard players reset * world_info
 
-# Misc
+# Forceload Staff World Platform
 execute in pandamium:staff_world run forceload add -1 -1 0 0
+
+# Useful Constants
 scoreboard players set <-1> variable -1
 scoreboard players set <16> variable 16
 scoreboard players set <32> variable 32

--- a/release_pandamium_datapack/data/pandamium/predicates/in_dimension/the_nether.json
+++ b/release_pandamium_datapack/data/pandamium/predicates/in_dimension/the_nether.json
@@ -1,0 +1,6 @@
+{
+	"condition": "location_check",
+	"predicate": {
+		"dimension": "the_nether"
+	}
+}

--- a/release_pandamium_datapack/data/pandamium/predicates/riding_minecart.json
+++ b/release_pandamium_datapack/data/pandamium/predicates/riding_minecart.json
@@ -1,0 +1,9 @@
+{
+	"condition": "entity_properties",
+	"entity": "this",
+	"predicate": {
+		"vehicle": {
+			"type": "minecart"
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/minecraft/advancements/husbandry/balanced_diet.json
+++ b/snapshot_pandamium_datapack/data/minecraft/advancements/husbandry/balanced_diet.json
@@ -1,0 +1,544 @@
+{
+	"parent": "pandamium:minecraft/husbandry/obtain_cake",
+	"display": {
+		"icon": {
+			"item": "apple"
+		},
+		"title": {
+			"translate": "advancements.husbandry.balanced_diet.title"
+		},
+		"description": {
+			"translate": "advancements.husbandry.balanced_diet.description"
+		},
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"apple": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"apple"
+					]
+				}
+			}
+		},
+		"baked_potato": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"baked_potato"
+					]
+				}
+			}
+		},
+		"beef": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"beef"
+					]
+				}
+			}
+		},
+		"beetroot": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"beetroot"
+					]
+				}
+			}
+		},
+		"beetroot_soup": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"beetroot_soup"
+					]
+				}
+			}
+		},
+		"bread": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"bread"
+					]
+				}
+			}
+		},
+		"carrot": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"carrot"
+					]
+				}
+			}
+		},
+		"chicken": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"chicken"
+					]
+				}
+			}
+		},
+		"chorus_fruit": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"chorus_fruit"
+					]
+				}
+			}
+		},
+		"cod": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cod"
+					]
+				}
+			}
+		},
+		"cooked_beef": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_beef"
+					]
+				}
+			}
+		},
+		"cooked_chicken": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_chicken"
+					]
+				}
+			}
+		},
+		"cooked_cod": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_cod"
+					]
+				}
+			}
+		},
+		"cooked_mutton": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_mutton"
+					]
+				}
+			}
+		},
+		"cooked_porkchop": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_porkchop"
+					]
+				}
+			}
+		},
+		"cooked_rabbit": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_rabbit"
+					]
+				}
+			}
+		},
+		"cooked_salmon": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cooked_salmon"
+					]
+				}
+			}
+		},
+		"cookie": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"cookie"
+					]
+				}
+			}
+		},
+		"dried_kelp": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"dried_kelp"
+					]
+				}
+			}
+		},
+		"enchanted_golden_apple": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"enchanted_golden_apple"
+					]
+				}
+			}
+		},
+		"glow_berries": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"glow_berries"
+					]
+				}
+			}
+		},
+		"golden_apple": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"golden_apple"
+					]
+				}
+			}
+		},
+		"golden_carrot": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"golden_carrot"
+					]
+				}
+			}
+		},
+		"honey_bottle": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"honey_bottle"
+					]
+				}
+			}
+		},
+		"melon_slice": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"melon_slice"
+					]
+				}
+			}
+		},
+		"mushroom_stew": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"mushroom_stew"
+					]
+				}
+			}
+		},
+		"mutton": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"mutton"
+					]
+				}
+			}
+		},
+		"poisonous_potato": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"poisonous_potato"
+					]
+				}
+			}
+		},
+		"porkchop": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"porkchop"
+					]
+				}
+			}
+		},
+		"potato": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"potato"
+					]
+				}
+			}
+		},
+		"pufferfish": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"pufferfish"
+					]
+				}
+			}
+		},
+		"pumpkin_pie": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"pumpkin_pie"
+					]
+				}
+			}
+		},
+		"rabbit": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"rabbit"
+					]
+				}
+			}
+		},
+		"rabbit_stew": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"rabbit_stew"
+					]
+				}
+			}
+		},
+		"rotten_flesh": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"rotten_flesh"
+					]
+				}
+			}
+		},
+		"salmon": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"salmon"
+					]
+				}
+			}
+		},
+		"spider_eye": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"spider_eye"
+					]
+				}
+			}
+		},
+		"suspicious_stew": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"suspicious_stew"
+					]
+				}
+			}
+		},
+		"sweet_berries": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"sweet_berries"
+					]
+				}
+			}
+		},
+		"tropical_fish": {
+			"trigger": "consume_item",
+			"conditions": {
+				"item": {
+					"items": [
+						"tropical_fish"
+					]
+				}
+			}
+		}
+	},
+	"requirements": [
+		[
+			"apple"
+		],
+		[
+			"mushroom_stew"
+		],
+		[
+			"bread"
+		],
+		[
+			"porkchop"
+		],
+		[
+			"cooked_porkchop"
+		],
+		[
+			"golden_apple"
+		],
+		[
+			"enchanted_golden_apple"
+		],
+		[
+			"cod"
+		],
+		[
+			"salmon"
+		],
+		[
+			"tropical_fish"
+		],
+		[
+			"pufferfish"
+		],
+		[
+			"cooked_cod"
+		],
+		[
+			"cooked_salmon"
+		],
+		[
+			"cookie"
+		],
+		[
+			"melon_slice"
+		],
+		[
+			"beef"
+		],
+		[
+			"cooked_beef"
+		],
+		[
+			"chicken"
+		],
+		[
+			"cooked_chicken"
+		],
+		[
+			"rotten_flesh"
+		],
+		[
+			"spider_eye"
+		],
+		[
+			"carrot"
+		],
+		[
+			"potato"
+		],
+		[
+			"baked_potato"
+		],
+		[
+			"poisonous_potato"
+		],
+		[
+			"golden_carrot"
+		],
+		[
+			"pumpkin_pie"
+		],
+		[
+			"rabbit"
+		],
+		[
+			"cooked_rabbit"
+		],
+		[
+			"rabbit_stew"
+		],
+		[
+			"mutton"
+		],
+		[
+			"cooked_mutton"
+		],
+		[
+			"chorus_fruit"
+		],
+		[
+			"beetroot"
+		],
+		[
+			"beetroot_soup"
+		],
+		[
+			"dried_kelp"
+		],
+		[
+			"suspicious_stew"
+		],
+		[
+			"sweet_berries"
+		],
+		[
+			"honey_bottle"
+		],
+		[
+			"glow_berries"
+		]
+	],
+	"rewards": {
+		"experience": 100
+	}
+}

--- a/snapshot_pandamium_datapack/data/minecraft/advancements/husbandry/obtain_netherite_hoe.json
+++ b/snapshot_pandamium_datapack/data/minecraft/advancements/husbandry/obtain_netherite_hoe.json
@@ -1,0 +1,39 @@
+{
+	"display": {
+		"icon": {
+			"item": "netherite_hoe",
+			"nbt": "{Damage:0}"
+		},
+		"title": {
+			"translate": "advancements.husbandry.netherite_hoe.title"
+		},
+		"description": "Use a Netherite Ingot to upgrade a Hoe",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"parent": "husbandry/plant_seed",
+	"criteria": {
+		"netherite_hoe": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": [
+							"netherite_hoe"
+						]
+					}
+				]
+			}
+		}
+	},
+	"requirements": [
+		[
+			"netherite_hoe"
+		]
+	],
+	"rewards": {
+		"experience": 100
+	}
+}

--- a/snapshot_pandamium_datapack/data/minecraft/advancements/story/mine_stone.json
+++ b/snapshot_pandamium_datapack/data/minecraft/advancements/story/mine_stone.json
@@ -1,0 +1,35 @@
+{
+	"display": {
+		"icon": {
+			"item": "wooden_pickaxe"
+		},
+		"title": {
+			"translate": "advancements.story.mine_stone.title"
+		},
+		"description": {
+			"translate": "advancements.story.mine_stone.description"
+		},
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true,
+		"hidden": false
+	},
+	"parent": "pandamium:minecraft/story/mine_log",
+	"criteria": {
+		"get_stone": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"tag": "stone_tool_materials"
+					}
+				]
+			}
+		}
+	},
+	"requirements": [
+		[
+			"get_stone"
+		]
+	]
+}

--- a/snapshot_pandamium_datapack/data/minecraft/advancements/story/mine_stone.json
+++ b/snapshot_pandamium_datapack/data/minecraft/advancements/story/mine_stone.json
@@ -14,7 +14,7 @@
 		"announce_to_chat": true,
 		"hidden": false
 	},
-	"parent": "pandamium:minecraft/story/mine_log",
+	"parent": "pandamium:minecraft/story/obtain_log",
 	"criteria": {
 		"get_stone": {
 			"trigger": "inventory_changed",

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/detect/place_wet_sponge.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/detect/place_wet_sponge.json
@@ -1,0 +1,23 @@
+{
+	"criteria": {
+		"place_wet_sponge": {
+			"trigger": "tick",
+			"conditions": {
+				"player": [
+					{
+						"condition": "entity_scores",
+						"entity": "this",
+						"scores": {
+							"detect.use.wet_sponge": {
+								"min": 1
+							}
+						}
+					}
+				]
+			}
+		}
+	},
+	"rewards": {
+		"function": "pandamium:misc/detect/place_wet_sponge"
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/detect/tie_dye_outfit.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/detect/tie_dye_outfit.json
@@ -1,0 +1,76 @@
+{
+	"criteria": {
+		"wear_leather_armor": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"player": [
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"head": {
+									"items": [
+										"leather_helmet"
+									]
+								}
+							}
+						}
+					},
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"chest": {
+									"items": [
+										"leather_chestplate"
+									]
+								}
+							}
+						}
+					},
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"legs": {
+									"items": [
+										"leather_leggings"
+									]
+								}
+							}
+						}
+					},
+					{
+						"condition": "entity_properties",
+						"entity": "this",
+						"predicate": {
+							"equipment": {
+								"feet": {
+									"items": [
+										"leather_boots"
+									]
+								}
+							}
+						}
+					}
+				],
+				"items": [
+					{
+						"items": [
+							"leather_boots",
+							"leather_leggings",
+							"leather_chestplate",
+							"leather_helmet"
+						]
+					}
+				]
+			}
+		}
+	},
+	"rewards": {
+		"function": "pandamium:misc/detect/tie_dye_outfit"
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/do_a_barrel_roll.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/do_a_barrel_roll.json
@@ -1,0 +1,18 @@
+{
+	"display": {
+		"icon": {
+			"item": "trident"
+		},
+		"title": "Do A Barrel Roll!",
+		"description": "Use the Riptide enchantment to give yourself a boost",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "adventure/throw_trident",
+	"criteria": {
+		"use_trident": {
+			"trigger": "impossible"
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/kill_an_elder_guardian.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/kill_an_elder_guardian.json
@@ -1,0 +1,23 @@
+{
+	"display": {
+		"icon": {
+			"item": "wet_sponge"
+		},
+		"title": "The Deep End",
+		"description": "Defeat an Elder Guardian",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "adventure/kill_a_mob",
+	"criteria": {
+		"kill_elder_guardian": {
+			"trigger": "player_killed_entity",
+			"conditions": {
+				"entity": {
+					"type": "elder_guardian"
+				}
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/overkill.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/adventure/overkill.json
@@ -1,0 +1,25 @@
+{
+	"parent": "adventure/kill_a_mob",
+	"display": {
+		"icon": {
+			"item": "netherite_sword"
+		},
+		"title": "Overkill",
+		"description": "Deal nine hearts of damage in a single hit.",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"deal_9_hearts_of_damage": {
+			"trigger": "player_hurt_entity",
+			"conditions": {
+				"damage": {
+					"dealt": {
+						"min": 18
+					}
+				}
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/end/break_elytra_in_sky.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/end/break_elytra_in_sky.json
@@ -4,7 +4,7 @@
 			"item": "elytra",
 			"nbt": "{Damage:432}"
 		},
-		"title": "Houston, We Have A Problem",
+		"title": "Minecraft, We Have A Problem",
 		"description": "Have your elytra break while above y-level 600",
 		"frame": "challenge",
 		"show_toast": true,

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/break_netherrite_hoe.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/break_netherrite_hoe.json
@@ -1,0 +1,30 @@
+{
+	"parent": "husbandry/obtain_netherite_hoe",
+	"display": {
+		"icon": {
+			"item": "netherite_hoe",
+			"nbt": "{Damage:2031}"
+		},
+		"title": "Life Choices",
+		"description": "Completely use up a netherite hoe, and then reevaluate your life choices",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"break_hoe": {
+			"trigger": "item_durability_changed",
+			"conditions": {
+				"durability": 0,
+				"item": {
+					"items": [
+						"netherite_hoe"
+					]
+				}
+			}
+		}
+	},
+	"rewards": {
+		"experience": 100
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_cake.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_cake.json
@@ -1,0 +1,27 @@
+{
+	"display": {
+		"icon": {
+			"item": "cake"
+		},
+		"title": "The Lie",
+		"description": "Bake a cake using: wheat, sugar, milk, and eggs",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "husbandry/plant_seed",
+	"criteria": {
+		"obtain_cake": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": [
+							"cake"
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_leather.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/obtain_leather.json
@@ -1,0 +1,27 @@
+{
+	"parent": "husbandry/root",
+	"display": {
+		"icon": {
+			"item": "leather"
+		},
+		"title": "Cow Tipper",
+		"description": "Harvest some leather",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"obtain_leather": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"items": [
+							"leather"
+						]
+					}
+				]
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/tie_dye_outfit.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/husbandry/tie_dye_outfit.json
@@ -1,0 +1,19 @@
+{
+	"parent": "pandamium:minecraft/husbandry/obtain_leather",
+	"display": {
+		"icon": {
+			"item": "leather_helmet",
+			"nbt": "{display:{color:13009364}}"
+		},
+		"title": "Tie Dye Outfit",
+		"description": "Uniquely dye and wear 4 mismatched pieces of leather armor",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"wear_tie_dyed_armour": {
+			"trigger": "impossible"
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/nether/dry_spell.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/nether/dry_spell.json
@@ -1,0 +1,18 @@
+{
+	"display": {
+		"icon": {
+			"item": "sponge"
+		},
+		"title": "Dry Spell",
+		"description": "Dry a sponge with the heat of the Nether",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "nether/root",
+	"criteria": {
+		"place_sponge_in_the_nether": {
+			"trigger": "impossible"
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/nether/stayin_frosty.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/nether/stayin_frosty.json
@@ -1,0 +1,27 @@
+{
+	"display": {
+		"icon": {
+			"item": "potion",
+			"nbt": "{Potion:\"fire_resistance\"}"
+		},
+		"title": "Stayin' Frosty",
+		"description": "Swim in lava while having the Fire Resistance effect",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "nether/brew_potion",
+	"criteria": {
+		"swim_in_lava": {
+			"trigger": "enter_block",
+			"conditions": {
+				"player": {
+					"effects": {
+						"fire_resistance": {}
+					}
+				},
+				"block": "lava"
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/diamonds_to_you.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/diamonds_to_you.json
@@ -15,7 +15,12 @@
 			"trigger": "thrown_item_picked_up_by_entity",
 			"conditions": {
 				"entity": {
-					"type": "player"
+					"type": "player",
+					"distance": {
+						"absolute": {
+							"min": 0.01
+						}
+					}
 				},
 				"item": {
 					"items": [

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/diamonds_to_you.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/diamonds_to_you.json
@@ -1,0 +1,28 @@
+{
+	"display": {
+		"icon": {
+			"item": "diamond"
+		},
+		"title": "Diamonds to You!",
+		"description": "Throw diamonds to another player",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"parent": "story/mine_diamond",
+	"criteria": {
+		"throw_diamond_to_a_player": {
+			"trigger": "thrown_item_picked_up_by_entity",
+			"conditions": {
+				"entity": {
+					"type": "player"
+				},
+				"item": {
+					"items": [
+						"diamond"
+					]
+				}
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/obtain_log.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/obtain_log.json
@@ -1,0 +1,25 @@
+{
+	"display": {
+		"icon": {
+			"item": "oak_log"
+		},
+		"title": "Getting Wood",
+		"description": "Punch a tree until a block of wood pops out",
+		"frame": "task",
+		"show_toast": true,
+		"announce_to_chat": false
+	},
+	"parent": "story/root",
+	"criteria": {
+		"obtain_log": {
+			"trigger": "inventory_changed",
+			"conditions": {
+				"items": [
+					{
+						"tag": "logs"
+					}
+				]
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/on_a_rail.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/minecraft/story/on_a_rail.json
@@ -1,0 +1,31 @@
+{
+	"parent": "minecraft:story/smelt_iron",
+	"display": {
+		"icon": {
+			"item": "rail"
+		},
+		"title": "On A Rail",
+		"description": "Travel at least 500m while in a minecart",
+		"frame": "challenge",
+		"show_toast": true,
+		"announce_to_chat": true
+	},
+	"criteria": {
+		"get_stone": {
+			"trigger": "location",
+			"conditions": {
+				"player": [
+					{
+						"condition": "entity_scores",
+						"entity": "this",
+						"scores": {
+							"detect.advancement.on_a_rail": {
+								"min": 50000
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/snapshot_pandamium_datapack/data/pandamium/advancements/pandamium/mob_heads/wear_bat_head.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/pandamium/mob_heads/wear_bat_head.json
@@ -5,7 +5,7 @@
 			"nbt": "{SkullOwner:{Id:[I;0,0,0,0],Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTU0MzhjM2I3MTVhNmFjNDU1YzBlM2M2NzU2ODgxNTMyNDIzOTEzNTc5ZDk4OTg4NTI1N2ZhZDU4YjY2OGQ5ZiJ9fX0=\"}]}}}"
 		},
 		"title": "I'm Batman!",
-		"description": "Wear a Bat Head",
+		"description": "Hide your identity with a Bat Head",
 		"frame": "task",
 		"show_toast": true
 	},

--- a/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -65,6 +65,7 @@ execute in pandamium:staff_world as @a[x=-6,y=63,z=8,dx=0,dy=3,dz=0] run functio
 function pandamium:misc/parkour/loop
 
 execute as @a[x=-512,y=75,z=-512,dx=1024,dy=245,dz=1024] at @s run advancement grant @s[x=0,z=0,distance=180..] only pandamium:run_once/walk_out_of_spawn
+scoreboard players reset @a[predicate=!pandamium:riding_minecart] detect.advancement.on_a_rail
 
 effect clear @a[scores={hidden=1..}]
 effect give @a[scores={hidden=1..}] invisibility 2 0 true

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/place_wet_sponge.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/place_wet_sponge.mcfunction
@@ -1,0 +1,4 @@
+execute if score @s in_dimension matches -1 run advancement grant @s only pandamium:minecraft/nether/dry_spell
+
+scoreboard players reset @s detect.use.wet_sponge
+advancement revoke @s only pandamium:detect/place_wet_sponge

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/tie_dye_outfit.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/tie_dye_outfit.mcfunction
@@ -1,0 +1,13 @@
+data modify storage pandamium:temp NBT set from entity @s
+
+scoreboard players set <all_dyed> variable 0
+execute store success score <all_dyed> variable if data storage pandamium:temp NBT.Inventory[{Slot:100b}].tag.display.color if data storage pandamium:temp NBT.Inventory[{Slot:101b}].tag.display.color if data storage pandamium:temp NBT.Inventory[{Slot:102b}].tag.display.color if data storage pandamium:temp NBT.Inventory[{Slot:103b}].tag.display.color
+
+execute if score <all_dyed> variable matches 1 store result score <boots_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:100b}].tag.display.color
+execute if score <all_dyed> variable matches 1 store result score <leggings_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:101b}].tag.display.color
+execute if score <all_dyed> variable matches 1 store result score <chestplate_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:102b}].tag.display.color
+execute if score <all_dyed> variable matches 1 store result score <helmet_color> variable run data get storage pandamium:temp NBT.Inventory[{Slot:103b}].tag.display.color
+
+execute if score <all_dyed> variable matches 1 unless score <boots_color> variable = <leggings_color> variable unless score <boots_color> variable = <chestplate_color> variable unless score <boots_color> variable = <helmet_color> variable unless score <leggings_color> variable = <chestplate_color> variable unless score <leggings_color> variable = <helmet_color> variable unless score <chestplate_color> variable = <helmet_color> variable run advancement grant @s only pandamium:minecraft/husbandry/tie_dye_outfit
+
+advancement revoke @s only pandamium:detect/tie_dye_outfit

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident.mcfunction
@@ -1,3 +1,5 @@
+advancement grant @s only pandamium:minecraft/adventure/do_a_barrel_roll
+
 execute store success score <has_advancement> variable if entity @s[advancements={pandamium:pandamium/mob_heads/blue_shell=true}]
 execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp NBT set from entity @s
 execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp HeadItem set value []

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident.mcfunction
@@ -1,12 +1,6 @@
-advancement grant @s only pandamium:minecraft/adventure/do_a_barrel_roll
+execute unless entity @s[advancements={pandamium:minecraft/adventure/do_a_barrel_roll=true,pandamium:pandamium/mob_heads/blue_shell=true}] run function pandamium:misc/detect/use_trident/check_advancements
 
-execute store success score <has_advancement> variable if entity @s[advancements={pandamium:pandamium/mob_heads/blue_shell=true}]
-execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp NBT set from entity @s
-execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp HeadItem set value []
-execute if score <has_advancement> variable matches 0 run data modify storage pandamium:temp HeadItem set from storage pandamium:temp NBT.Inventory[{Slot:103b}]
-execute if score <has_advancement> variable matches 0 if data storage pandamium:temp HeadItem{id:'minecraft:player_head',tag:{SkullOwner:{Name:"§lTurtle"}}} if data storage pandamium:temp NBT.SelectedItem{id:'minecraft:trident'}.tag.Enchantments[{id:'minecraft:riptide'}] run advancement grant @s only pandamium:pandamium/mob_heads/blue_shell
-
-execute if score @s parkour.checkpoint matches 1.. run advancement grant @s only pandamium:detect/parkour/cheat
+execute if score @s parkour.checkpoint matches 0.. run advancement grant @s only pandamium:detect/parkour/cheat
 
 scoreboard players reset @s detect.use.trident
 advancement revoke @s only pandamium:detect/use_trident

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident/check_advancements.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/use_trident/check_advancements.mcfunction
@@ -1,0 +1,8 @@
+data modify storage pandamium:temp NBT set from entity @s
+execute store success score <has_riptide> variable if data storage pandamium:temp NBT.SelectedItem{id:'minecraft:trident'}.tag.Enchantments[{id:'minecraft:riptide'}]
+
+execute if score <has_riptide> variable matches 1 run advancement grant @s only pandamium:minecraft/adventure/do_a_barrel_roll
+
+data modify storage pandamium:temp HeadItem set value {}
+data modify storage pandamium:temp HeadItem set from storage pandamium:temp NBT.Inventory[{Slot:103b}]
+execute if data storage pandamium:temp HeadItem{id:'minecraft:player_head',tag:{SkullOwner:{Name:"§lTurtle"}}} if score <has_riptide> variable matches 1 run advancement grant @s only pandamium:pandamium/mob_heads/blue_shell

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -189,6 +189,7 @@ scoreboard objectives add detect.die deathCount
 scoreboard objectives add detect.use.ender_pearl used:ender_pearl
 scoreboard objectives add detect.use.trident used:trident
 scoreboard objectives add detect.aviate custom:aviate_one_cm
+scoreboard objectives add detect.advancement.on_a_rail custom:minecart_one_cm
 
 scoreboard objectives add parkour.timer_ticks dummy
 scoreboard objectives add parkour.checkpoint dummy

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -188,6 +188,7 @@ scoreboard objectives add detect.leave_game custom:leave_game
 scoreboard objectives add detect.die deathCount
 scoreboard objectives add detect.use.ender_pearl used:ender_pearl
 scoreboard objectives add detect.use.trident used:trident
+scoreboard objectives add detect.use.wet_sponge used:wet_sponge
 scoreboard objectives add detect.aviate custom:aviate_one_cm
 scoreboard objectives add detect.advancement.on_a_rail custom:minecart_one_cm
 
@@ -352,7 +353,7 @@ team join gray_color MobCap:
 team add dragon_fight
 team modify dragon_fight friendlyFire false
 
-# Forceload Staff World Chunk
+# Forceload Staff World Platform
 execute in pandamium:staff_world run forceload add -1 -1 0 0
 execute in pandamium:staff_world unless block 6 64 3 oak_wall_sign run setblock 6 64 3 oak_wall_sign[facing=west]{Text2:'{"text":"[Restore Lore]","bold":true,"clickEvent":{"action":"run_command","value":"/function pandamium:misc/jail_items/restore_lore/main"}}'}
 

--- a/snapshot_pandamium_datapack/data/pandamium/predicates/riding_minecart.json
+++ b/snapshot_pandamium_datapack/data/pandamium/predicates/riding_minecart.json
@@ -1,0 +1,9 @@
+{
+	"condition": "entity_properties",
+	"entity": "this",
+	"predicate": {
+		"vehicle": {
+			"type": "minecart"
+		}
+	}
+}


### PR DESCRIPTION
Added a bunch of advancements to the vanilla advancement trees, inspired by Legacy Achievements

Getting Wood - Punch a tree until a block of wood pops out.
Life Choices - Completely use up a netherite hoe, and then reevaluate your life choices.
On A Rail - Travel at least 500m while in a minecart.
The Lie - Bake a cake using: wheat, sugar, milk, and eggs.
Overkill - Deal nine hearts of damage in a single hit.
The Deep End - Defeat an Elder Guardian
Dry Spell - Dry a sponge in the nether
Diamonds to you! - Throw diamonds to another player.
Stayin' Frosty - Swim in lava while having the Fire Resistance effect.
Tie Dye Outfit - Dye and wear 4 unique pieces of leather armour.
Do a Barrel Roll! - Use Riptide to give yourself a boost

Renamed "Houston, We Have A Problem" to "Minecraft, We Have A Problem"