### PR TITLE
Chat Leaderboards small fixes/changes

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/get_username.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/get_username.mcfunction
@@ -1,4 +1,3 @@
-# run IN pandamium:staff_world
-setblock 0 0 0 chest
-loot replace block 0 0 0 container.0 loot pandamium:head
-data modify storage pandamium:temp username set from block 0 0 0 Items[0].tag.SkullOwner.Name
+execute in pandamium:staff_world run setblock 0 0 0 barrel
+execute in pandamium:staff_world run loot replace block 0 0 0 container.0 loot pandamium:head
+execute in pandamium:staff_world run data modify storage pandamium:temp username set from block 0 0 0 Items[0].tag.SkullOwner.Name

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/leaderboards/get_self.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/leaderboards/get_self.mcfunction
@@ -1,9 +1,11 @@
-data modify storage pandamium:temp leaderboards.self set value {value:0}
+data modify storage pandamium:temp leaderboards.self set value {value:-2147483648}
 execute store result storage pandamium:temp leaderboards.self.id int 1 run scoreboard players operation <self_id> variable = @s id
 
 tag @s add self
 execute in pandamium:staff_world run setblock 0 0 0 air
 execute in pandamium:staff_world run setblock 0 0 0 oak_sign{Text1:'{"selector":"@a[tag=self,limit=1]"}'}
 tag @s remove self
-
 execute in pandamium:staff_world run data modify storage pandamium:temp leaderboards.self.display_name set from block 0 0 0 Text1
+
+function pandamium:misc/get_username
+data modify storage pandamium:temp leaderboards.self.username set from storage pandamium:temp username


### PR DESCRIPTION
- Added plain-text `username` nbt to all entries
- Default entries should now, everywhere, be set to the negative integer limit 