### PR TITLE
fixed monthly leaderboard resets

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/tags/functions/leaderboards/reset/monthly.json
+++ b/snapshot_pandamium_datapack/data/pandamium/tags/functions/leaderboards/reset/monthly.json
@@ -1,6 +1,6 @@
 {
 	"values": [
-		"pandamium:misc/leaderboards/update_self/monthly_playtime",
-		"pandamium:misc/leaderboards/update_self/monthly_votes"
+		"pandamium:misc/leaderboards/reset/monthly_playtime",
+		"pandamium:misc/leaderboards/reset/monthly_votes"
 	]
 }


### PR DESCRIPTION
- Leaderboards should properly get backed up and reset at the beginning of each month