### PR TITLE
made obsidian immune to wither damage

### DIFF
--- a/release_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
+++ b/release_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"obsidian"
+	]
+}

--- a/snapshot_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
+++ b/snapshot_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"obsidian"
+	]
+}


### PR DESCRIPTION
Added obsidian to the list of blocks that withers cannot break by walking into it.
This should allow for farm designs which do not rely on the nether roof