### PR TITLE
changed wither-immune obsidian to crying obsidian

### DIFF
--- a/release_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
+++ b/release_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
@@ -1,5 +1,5 @@
 {
 	"values": [
-		"obsidian"
+		"crying_obsidian"
 	]
 }

--- a/snapshot_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
+++ b/snapshot_pandamium_datapack/data/minecraft/tags/blocks/wither_immune.json
@@ -1,5 +1,5 @@
 {
 	"values": [
-		"obsidian"
+		"crying_obsidian"
 	]
 }


### PR DESCRIPTION
- To prevent obsidian farms breaking (and add more use to Crying Obsidian), Crying Obsidian will be wither-immune, and not Obsidian