### PR TITLE
pose fixes

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/mirror.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/mirror.mcfunction
@@ -1,52 +1,52 @@
-data modify storage pandamium:temp pose.mirror set from storage pandamium:temp pose.NBT.Pose
+data modify storage pandamium:temp pose.mirror set from storage pandamium:temp pose.nbt.Pose
 
 # Head
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.Head[1] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.Head[1] -1
 execute store result storage pandamium:temp pose.mirror.Head[1] float 1 run scoreboard players add <angle> variable 360
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.Head[2] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.Head[2] -1
 execute store result storage pandamium:temp pose.mirror.Head[2] float 1 run scoreboard players add <angle> variable 360
 
 # Body
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.Body[1] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.Body[1] -1
 execute store result storage pandamium:temp pose.mirror.Body[1] float 1 run scoreboard players add <angle> variable 360
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.Body[2] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.Body[2] -1
 execute store result storage pandamium:temp pose.mirror.Body[2] float 1 run scoreboard players add <angle> variable 360
 
 # Left Arm
-data modify storage pandamium:temp pose.mirror.LeftArm[0] set from storage pandamium:temp pose.NBT.Pose.RightArm[0]
+data modify storage pandamium:temp pose.mirror.LeftArm[0] set from storage pandamium:temp pose.nbt.Pose.RightArm[0]
 
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.RightArm[1] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.RightArm[1] -1
 execute store result storage pandamium:temp pose.mirror.LeftArm[1] float 1 run scoreboard players add <angle> variable 360
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.RightArm[2] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.RightArm[2] -1
 execute store result storage pandamium:temp pose.mirror.LeftArm[2] float 1 run scoreboard players add <angle> variable 360
 
 # Right Arm
-data modify storage pandamium:temp pose.mirror.RightArm[0] set from storage pandamium:temp pose.NBT.Pose.LeftArm[0]
+data modify storage pandamium:temp pose.mirror.RightArm[0] set from storage pandamium:temp pose.nbt.Pose.LeftArm[0]
 
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.LeftArm[1] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.LeftArm[1] -1
 execute store result storage pandamium:temp pose.mirror.RightArm[1] float 1 run scoreboard players add <angle> variable 360
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.LeftArm[2] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.LeftArm[2] -1
 execute store result storage pandamium:temp pose.mirror.RightArm[2] float 1 run scoreboard players add <angle> variable 360
 
 # Left Leg
-data modify storage pandamium:temp pose.mirror.LeftLeg[0] set from storage pandamium:temp pose.NBT.Pose.RightLeg[0]
+data modify storage pandamium:temp pose.mirror.LeftLeg[0] set from storage pandamium:temp pose.nbt.Pose.RightLeg[0]
 
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.RightLeg[1] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.RightLeg[1] -1
 execute store result storage pandamium:temp pose.mirror.LeftLeg[1] float 1 run scoreboard players add <angle> variable 360
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.RightLeg[2] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.RightLeg[2] -1
 execute store result storage pandamium:temp pose.mirror.LeftLeg[2] float 1 run scoreboard players add <angle> variable 360
 
 # Right Leg
-data modify storage pandamium:temp pose.mirror.RightLeg[0] set from storage pandamium:temp pose.NBT.Pose.LeftLeg[0]
+data modify storage pandamium:temp pose.mirror.RightLeg[0] set from storage pandamium:temp pose.nbt.Pose.LeftLeg[0]
 
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.LeftLeg[1] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.LeftLeg[1] -1
 execute store result storage pandamium:temp pose.mirror.RightLeg[1] float 1 run scoreboard players add <angle> variable 360
-execute store result score <angle> variable run data get storage pandamium:temp pose.NBT.Pose.LeftLeg[2] -1
+execute store result score <angle> variable run data get storage pandamium:temp pose.nbt.Pose.LeftLeg[2] -1
 execute store result storage pandamium:temp pose.mirror.RightLeg[2] float 1 run scoreboard players add <angle> variable 360
 
 # Transfer New Pose
 data modify entity @s Pose set from storage pandamium:temp pose.mirror
-data modify entity @s HandItems prepend from storage pandamium:temp pose.NBT.HandItems[1]
+data modify entity @s HandItems prepend from storage pandamium:temp pose.nbt.HandItems[1]
 
 execute store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"[Pose]","color":"dark_green"},{"text":" Mirrored ","color":"aqua"},{"text":"Pose!","color":"green"}]
 scoreboard players set <sound> variable 1

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/swap_item.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/swap_item.mcfunction
@@ -1,13 +1,16 @@
 execute in pandamium:staff_world run setblock 0 0 0 barrel
 
-execute if score <pose> variable matches -302 in pandamium:staff_world run item replace block 0 0 0 container.0 from entity @s armor.head
-execute if score <pose> variable matches -302 run item replace entity @s armor.head from entity @p[tag=running_trigger] weapon.mainhand
-execute if score <pose> variable matches -302 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Swapped the nearest armour stand's ",{"text":"head","color":"aqua"}," slot and your selected item!"]
+scoreboard players set <cannot_swap> variable 0
+execute if data entity @s {Invisible:1b} as @p[tag=running_trigger] unless predicate pandamium:holding_an_item store success score <cannot_swap> variable store success score <returned> variable run tellraw @s [{"text":"","color":"red"},{"text":"[Pose]","color":"dark_red"}," You cannot take items off of an armour stand while it is invisible!"]
 
-execute if score <pose> variable matches -303 in pandamium:staff_world run item replace block 0 0 0 container.0 from entity @s weapon.offhand
-execute if score <pose> variable matches -303 run item replace entity @s weapon.offhand from entity @p[tag=running_trigger] weapon.mainhand
-execute if score <pose> variable matches -303 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Swapped the nearest armour stand's ",{"text":"off-hand","color":"aqua"}," slot and your selected item!"]
+execute if score <cannot_swap> variable matches 0 if score <pose> variable matches -302 in pandamium:staff_world run item replace block 0 0 0 container.0 from entity @s armor.head
+execute if score <cannot_swap> variable matches 0 if score <pose> variable matches -302 run item replace entity @s armor.head from entity @p[tag=running_trigger] weapon.mainhand
+execute if score <cannot_swap> variable matches 0 if score <pose> variable matches -302 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Swapped the nearest armour stand's ",{"text":"head","color":"aqua"}," slot and your selected item!"]
 
-execute in pandamium:staff_world run item replace entity @p[tag=running_trigger] weapon.mainhand from block 0 0 0 container.0
+execute if score <cannot_swap> variable matches 0 if score <pose> variable matches -303 in pandamium:staff_world run item replace block 0 0 0 container.0 from entity @s weapon.offhand
+execute if score <cannot_swap> variable matches 0 if score <pose> variable matches -303 run item replace entity @s weapon.offhand from entity @p[tag=running_trigger] weapon.mainhand
+execute if score <cannot_swap> variable matches 0 if score <pose> variable matches -303 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Swapped the nearest armour stand's ",{"text":"off-hand","color":"aqua"}," slot and your selected item!"]
+
+execute if score <cannot_swap> variable matches 0 in pandamium:staff_world run item replace entity @p[tag=running_trigger] weapon.mainhand from block 0 0 0 container.0
 
 scoreboard players set <sound> variable 3

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/toggle_attribute.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/toggle_attribute.mcfunction
@@ -1,27 +1,27 @@
 scoreboard players set <sound> variable 1
 
-execute if score <pose> variable matches -101 store success score <value> variable store success entity @s ShowArms byte 1 unless data storage pandamium:temp pose.NBT{ShowArms:1b}
+execute if score <pose> variable matches -101 store success score <value> variable store success entity @s ShowArms byte 1 unless data storage pandamium:temp pose.nbt{ShowArms:1b}
 execute if score <pose> variable matches -101 if score <value> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"ShowArms","color":"aqua"}," to ",{"text":"true","color":"yellow"},"!"]
 execute if score <pose> variable matches -101 if score <value> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"ShowArms","color":"aqua"}," to ",{"text":"false","color":"yellow"},"!"]
 
-execute if score <pose> variable matches -102 store success score <value> variable store success entity @s NoBasePlate byte 1 unless data storage pandamium:temp pose.NBT{NoBasePlate:1b}
+execute if score <pose> variable matches -102 store success score <value> variable store success entity @s NoBasePlate byte 1 unless data storage pandamium:temp pose.nbt{NoBasePlate:1b}
 execute if score <pose> variable matches -102 if score <value> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"NoBasePlate","color":"aqua"}," to ",{"text":"true","color":"yellow"},"!"]
 execute if score <pose> variable matches -102 if score <value> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"NoBasePlate","color":"aqua"}," to ",{"text":"false","color":"yellow"},"!"]
 
-execute if score <pose> variable matches -103 store success score <value> variable store success entity @s NoGravity byte 1 unless data storage pandamium:temp pose.NBT{NoGravity:1b}
+execute if score <pose> variable matches -103 store success score <value> variable store success entity @s NoGravity byte 1 unless data storage pandamium:temp pose.nbt{NoGravity:1b}
 execute if score <pose> variable matches -103 if score <value> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"NoGravity","color":"aqua"}," to ",{"text":"true","color":"yellow"},"!"]
 execute if score <pose> variable matches -103 if score <value> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"NoGravity","color":"aqua"}," to ",{"text":"false","color":"yellow"},"!"]
 
-execute if score <pose> variable matches -104 store success score <value> variable store success entity @s Small byte 1 unless data storage pandamium:temp pose.NBT{Small:1b}
+execute if score <pose> variable matches -104 store success score <value> variable store success entity @s Small byte 1 unless data storage pandamium:temp pose.nbt{Small:1b}
 execute if score <pose> variable matches -104 if score <value> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"Small","color":"aqua"}," to ",{"text":"true","color":"yellow"},"!"]
 execute if score <pose> variable matches -104 if score <value> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"Small","color":"aqua"}," to ",{"text":"false","color":"yellow"},"!"]
 
-execute if score <pose> variable matches -105 store success score <value> variable store success entity @s CustomNameVisible byte 1 unless data storage pandamium:temp pose.NBT{CustomNameVisible:1b}
+execute if score <pose> variable matches -105 store success score <value> variable store success entity @s CustomNameVisible byte 1 unless data storage pandamium:temp pose.nbt{CustomNameVisible:1b}
 execute if score <pose> variable matches -105 if score <value> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"CustomNameVisible","color":"aqua"}," to ",{"text":"true","color":"yellow"},"!"]
 execute if score <pose> variable matches -105 if score <value> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"CustomNameVisible","color":"aqua"}," to ",{"text":"false","color":"yellow"},"!"]
 
 execute if score <pose> variable matches -106 run function pandamium:misc/pose/actions/toggle_invisible
 
-execute if score <pose> variable matches -107 store success score <value> variable store success entity @s HasVisualFire byte 1 unless data storage pandamium:temp pose.NBT{HasVisualFire:1b}
+execute if score <pose> variable matches -107 store success score <value> variable store success entity @s HasVisualFire byte 1 unless data storage pandamium:temp pose.nbt{HasVisualFire:1b}
 execute if score <pose> variable matches -107 if score <value> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"HasVisualFire","color":"aqua"}," to ",{"text":"true","color":"yellow"},"!"]
 execute if score <pose> variable matches -107 if score <value> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"HasVisualFire","color":"aqua"}," to ",{"text":"false","color":"yellow"},"!"]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/toggle_invisible.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/actions/toggle_invisible.mcfunction
@@ -1,12 +1,12 @@
-execute store success score <is_invisible> variable if data storage pandamium:temp pose.NBT{Invisible:1b}
+execute store success score <is_invisible> variable if data storage pandamium:temp pose.nbt{Invisible:1b}
 scoreboard players set <can_toggle_invisible> variable 0
-execute if data storage pandamium:temp pose.NBT.ArmorItems[].id run scoreboard players set <can_toggle_invisible> variable 1
-execute if data storage pandamium:temp pose.NBT.HandItems[].id run scoreboard players set <can_toggle_invisible> variable 1
+execute if data storage pandamium:temp pose.nbt.ArmorItems[].id run scoreboard players set <can_toggle_invisible> variable 1
+execute if data storage pandamium:temp pose.nbt.HandItems[].id run scoreboard players set <can_toggle_invisible> variable 1
 
-execute if score <is_invisible> variable matches 1 run data merge entity @s {Invisible:0b,DisabledSlots:0}
-execute if score <is_invisible> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"Invisible","color":"aqua"},"to ",{"text":"false","color":"yellow"},"!"]
+execute if score <is_invisible> variable matches 1 if score <can_toggle_invisible> variable matches 1 run data merge entity @s {Invisible:0b,DisabledSlots:0}
+execute if score <is_invisible> variable matches 1 if score <can_toggle_invisible> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"Invisible","color":"aqua"}," to ",{"text":"false","color":"yellow"},"!"]
 
 execute if score <is_invisible> variable matches 0 if score <can_toggle_invisible> variable matches 1 run data merge entity @s {Invisible:1b,DisabledSlots:4144959}
-execute if score <is_invisible> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"Invisible","color":"aqua"},"to ",{"text":"true","color":"yellow"},"!"]
+execute if score <is_invisible> variable matches 0 if score <can_toggle_invisible> variable matches 1 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"","color":"green"},{"text":"[Pose]","color":"dark_green"}," Set ",{"text":"Invisible","color":"aqua"}," to ",{"text":"true","color":"yellow"},"!"]
 
 execute if score <is_invisible> variable matches 0 if score <can_toggle_invisible> variable matches 0 store success score <returned> variable run tellraw @p[tag=running_trigger] [{"text":"[Pose]","color":"dark_red"},{"text":" You can only make armour stands invisible if they have items on them!","color":"red"}]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/target_new.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/pose/target_new.mcfunction
@@ -3,5 +3,5 @@
 scoreboard players set <armor_stand_exists> variable 1
 particle wax_off ~ ~1 ~ 0.2 0.4 0.2 0.2 10
 
-data modify storage pandamium:temp pose.NBT set from entity @s
+data modify storage pandamium:temp pose.nbt set from entity @s
 function pandamium:misc/pose/do_edit

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/raycast/armor_stand/at_ray.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/raycast/armor_stand/at_ray.mcfunction
@@ -1,0 +1,3 @@
+tp @s ~ ~ ~ ~ ~
+execute at @s run function pandamium:misc/raycast/armor_stand/iter
+kill

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/raycast/armor_stand/iter.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/raycast/armor_stand/iter.mcfunction
@@ -1,0 +1,6 @@
+execute as @e[dx=0,type=armor_stand] positioned ~-1 ~-1 ~-1 if entity @s[dx=0] store success score <raycast_in_block> variable run tag @s add raycast.selected
+execute unless block ~ ~ ~ #pandamium:raycast_continue run scoreboard players set <ttl> variable 0
+
+scoreboard players remove <ttl> variable 1
+execute if score <raycast_in_block> variable matches 0 if score <ttl> variable matches 1.. run tp ^ ^ ^0.03125
+execute if score <raycast_in_block> variable matches 0 if score <ttl> variable matches 1.. at @s run function pandamium:misc/raycast/armor_stand/iter

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/raycast/armor_stand/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/raycast/armor_stand/main.mcfunction
@@ -1,0 +1,8 @@
+execute as @e[type=marker,tag=raycast.ray] run function pandamium:misc/raycast/kill_marker_vibration_fix
+tag @e remove raycast.selected
+
+scoreboard players set <ttl> variable 160
+scoreboard players set <raycast_in_block> variable 0
+
+summon marker ~ ~ ~ {Tags:["raycast.ray","raycast.armor_stand"]}
+execute at @s anchored eyes positioned ^ ^ ^ as @e[type=marker,tag=raycast.ray,limit=1,sort=nearest] run function pandamium:misc/raycast/armor_stand/at_ray

--- a/snapshot_pandamium_datapack/data/pandamium/functions/triggers/pose.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/triggers/pose.mcfunction
@@ -16,8 +16,9 @@ execute if score <returned> variable matches 0 if entity @s[gamemode=spectator] 
 scoreboard players operation <pose> variable = @s pose
 
 scoreboard players set <armor_stand_exists> variable 0
-execute if score <returned> variable matches 0 as @e[type=armor_stand,distance=..7,limit=1,sort=nearest,tag=!pose.locked] at @s run function pandamium:misc/pose/target_new
-execute if score <returned> variable matches 0 if score <armor_stand_exists> variable matches 0 store success score <returned> variable run tellraw @s [{"text":"[Pose]","color":"dark_red"},{"text":" Could not find a posable armour stand nearby! You must be standing within 7 blocks of a posable armour stand to use this trigger.","color":"red"}]
+execute if score <returned> variable matches 0 run function pandamium:misc/raycast/armor_stand/main
+execute if score <returned> variable matches 0 positioned ~-8 ~-8 ~-8 as @e[type=armor_stand,dx=16,dy=16,dz=16,tag=raycast.selected,tag=!pose.locked,limit=1] at @s run function pandamium:misc/pose/target_new
+execute if score <returned> variable matches 0 if score <armor_stand_exists> variable matches 0 store success score <returned> variable run tellraw @s [{"text":"[Pose]","color":"dark_red"},{"text":" You are not looking at a poseable armour stand!","color":"red"}]
 
 execute if score <returned> variable matches 1 if score <sound> variable matches 1.. run function pandamium:misc/pose/sound
 execute if score <returned> variable matches 0 run tellraw @s [{"text":"[Pose] ","color":"dark_red"},{"text":"That is not a valid option!","color":"red"}]

--- a/snapshot_pandamium_datapack/data/pandamium/predicates/holding_an_item.json
+++ b/snapshot_pandamium_datapack/data/pandamium/predicates/holding_an_item.json
@@ -1,0 +1,16 @@
+{
+	"condition": "minecraft:inverted",
+	"term": {
+		"condition": "minecraft:entity_properties",
+		"entity": "this",
+		"predicate": {
+			"equipment": {
+				"mainhand": {
+					"items": [
+						"minecraft:air"
+					]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Fixed error message for Invisible toggle.
- Now targets the armour stand you are looking at, rather than the nearest one.
- You can no longer swap items while the armour stand is invisible if you aren't holding anything.