### PR TITLE
added bookshelf dupe staff warning

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/bookshelf_dupe_fix/use_book_on_filled_bookshelf.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/bookshelf_dupe_fix/use_book_on_filled_bookshelf.mcfunction
@@ -1,3 +1,8 @@
 advancement revoke @s only pandamium:detect/bookshelf_dupe_fix/use_book_on_filled_bookshelf
 
 item modify entity @s weapon.mainhand pandamium:decrement_count
+
+scoreboard players add @s detect.bookshelf_dupe_patch_counter 1
+
+execute if score @s detect.bookshelf_dupe_patch_counter matches 2.. run tellraw @a[scores={staff_perms=1..}] [{"text":"[Info] ","color":"dark_gray"},{"selector":"@s","color":"gray"},{"text":" might be trying to exploit a duplication bug.","color":"gray"}]
+execute if score @s detect.bookshelf_dupe_patch_counter matches 2.. run scoreboard players reset @s detect.bookshelf_dupe_patch_counter

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -191,6 +191,7 @@ scoreboard objectives add detect.use.wet_sponge used:wet_sponge
 scoreboard objectives add detect.aviate custom:aviate_one_cm
 scoreboard objectives add detect.take_damage custom:damage_taken
 scoreboard objectives add detect.advancement.on_a_rail custom:minecart_one_cm
+scoreboard objectives add detect.bookshelf_dupe_patch_counter dummy
 
 scoreboard objectives add parkour.timer_ticks dummy
 scoreboard objectives add parkour.checkpoint dummy
@@ -285,6 +286,7 @@ scoreboard players reset * detect.use.wet_sponge
 scoreboard players reset * detect.aviate
 scoreboard players reset * detect.take_damage
 scoreboard players reset * detect.advancement.on_a_rail
+scoreboard players reset * detect.bookshelf_dupe_patch_counter
 
 # Teams
 team add guest


### PR DESCRIPTION
If a player attempts to perform the bookshelf dupe twice, it will notify staff in chat.