### PR TITLE
fixes for death events

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/die.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/die.mcfunction
@@ -1,4 +1,4 @@
-execute if entity @s[gamemode=!spectator] if score @s detect.die matches 1.. if score @s death_particles matches 1.. unless score @s hidden matches 1.. at @s if entity @a[distance=..64,limit=1] run function pandamium:misc/particles/death_event
-execute if entity @s[predicate=!pandamium:in_dimension/staff_world,predicate=!pandamium:in_spawn,gamemode=survival] if score @s detect.die matches 1.. if score @s disable_keep_inventory matches 1 in pandamium:staff_world if blocks 0 0 0 0 0 0 0 0 0 all run function pandamium:misc/drop_inventory_items
+execute if score @s death_particles matches 1.. if entity @s[gamemode=!spectator] unless score @s hidden matches 1.. at @s if entity @a[distance=..64,limit=1] run function pandamium:misc/particles/death_event
+execute if score @s disable_keep_inventory matches 1 if entity @s[predicate=!pandamium:in_dimension/staff_world,predicate=!pandamium:in_spawn,gamemode=survival] in pandamium:staff_world if blocks 0 0 0 0 0 0 0 0 0 all run function pandamium:misc/drop_inventory_items
 
 scoreboard players reset @s detect.die

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/die.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/die.mcfunction
@@ -1,7 +1,4 @@
-scoreboard players reset @s[predicate=pandamium:in_spawn] detect.die
-execute in pandamium:staff_world run scoreboard players reset @a[x=0] detect.die
-
-execute if score @s death_particles matches 1.. unless score @s hidden matches 1.. at @s if entity @a[distance=..64] run function pandamium:misc/particles/death_event
-execute if score @s disable_keep_inventory matches 1 if entity @s[gamemode=survival] in pandamium:staff_world if blocks 0 0 0 0 0 0 0 0 0 all run function pandamium:misc/drop_inventory_items
+execute if entity @s[gamemode=!spectator] if score @s detect.die matches 1.. if score @s death_particles matches 1.. unless score @s hidden matches 1.. at @s if entity @a[distance=..64,limit=1] run function pandamium:misc/particles/death_event
+execute if entity @s[predicate=!pandamium:in_dimension/staff_world,predicate=!pandamium:in_spawn,gamemode=survival] if score @s detect.die matches 1.. if score @s disable_keep_inventory matches 1 in pandamium:staff_world if blocks 0 0 0 0 0 0 0 0 0 all run function pandamium:misc/drop_inventory_items
 
 scoreboard players reset @s detect.die


### PR DESCRIPTION
- dying while in spectator mode (`/trigger respawn`) should no longer trigger death event particles
- optimised checks