### PR TITLE
switched shulker box trick to standardised loot table

### DIFF
--- a/snapshot_pandamium_datapack/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
+++ b/snapshot_pandamium_datapack/data/minecraft/loot_tables/blocks/yellow_shulker_box.json
@@ -22,7 +22,7 @@
 						},
 						{
 							"type": "item",
-							"name": "shulker_box",
+							"name": "yellow_shulker_box",
 							"functions": [
 								{
 									"function": "copy_name",

--- a/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/nbt.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/nbt.mcfunction
@@ -15,6 +15,7 @@ data remove storage pandamium:containers displayed_tag.StoredEnchantments
 execute if data storage pandamium:containers item{id:"minecraft:written_book"} run data remove storage pandamium:containers displayed_tag.title
 execute if data storage pandamium:containers item{id:"minecraft:written_book"} run data remove storage pandamium:containers displayed_tag.author
 data remove storage pandamium:containers displayed_tag.display.Name
+data remove storage pandamium:containers displayed_tag.SkullOwner.Name
 execute store result score <modified_compound_size> variable run data get storage pandamium:containers displayed_tag.display
 execute if score <modified_compound_size> variable matches 0 run data remove storage pandamium:containers displayed_tag.display
 

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory_items.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory_items.mcfunction
@@ -2,7 +2,7 @@
 
 tag @e[x=0,y=0,z=0,dx=0,dy=0,dz=0,type=item] add ignore
 
-setblock 0 0 0 shulker_box
+setblock 0 0 0 yellow_shulker_box
 data modify block 0 0 0 Items set from entity @s Inventory
 data remove block 0 0 0 Items[{tag:{Enchantments:[{id:"minecraft:vanishing_curse"}]}}]
 loot spawn 0 0 0 mine 0 0 0 air{drop_contents:1b}

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/jail_items/do_transfer.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/jail_items/do_transfer.mcfunction
@@ -9,7 +9,7 @@ data modify storage pandamium:temp Item.tag.display.Lore[1] set from block 0 2 0
 
 data modify storage pandamium:temp Items set value [{Slot:0b}]
 data modify storage pandamium:temp Items[0] merge from storage pandamium:temp Item
-setblock 0 1 0 shulker_box
+setblock 0 1 0 yellow_shulker_box
 data modify block 0 1 0 Items set from storage pandamium:temp Items
 
 summon marker 7 64 2 {Tags:["jail_items_marker"]}

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/jail_items/restore_lore/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/jail_items/restore_lore/main.mcfunction
@@ -1,6 +1,6 @@
 # run IN pandamium:staff_world
 
-setblock 0 0 0 shulker_box
+setblock 0 0 0 yellow_shulker_box
 
 execute store result score <jail_items_in_inventory> variable if data entity @s Inventory[].tag.pandamium.jail_item
 

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/unequip_armour.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/unequip_armour.mcfunction
@@ -2,7 +2,7 @@
 
 # If there is not at least 4 empty inventory slots, the items will be deleted without warning. Use the function "pandamium:misc/count_filled_inventory_slots" to check how many slots are available before running this function.
 
-setblock 0 0 0 shulker_box
+setblock 0 0 0 yellow_shulker_box
 
 item replace block 0 0 0 container.0 from entity @s armor.feet
 item replace block 0 0 0 container.1 from entity @s armor.legs

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/unequip_armour_and_hands.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/unequip_armour_and_hands.mcfunction
@@ -2,7 +2,7 @@
 
 # If there is not at least 6 empty inventory slots (assume mainhand slot is filled), the items will be deleted without warning. Use the function "pandamium:misc/count_filled_inventory_slots" to check how many slots are available before running this function.
 
-setblock 0 0 0 shulker_box
+setblock 0 0 0 yellow_shulker_box
 
 item replace block 0 0 0 container.0 from entity @s armor.feet
 item replace block 0 0 0 container.1 from entity @s armor.legs

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/unequip_chest_slot.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/unequip_chest_slot.mcfunction
@@ -2,7 +2,7 @@
 
 # If there is not at least 1 empty inventory slot, the item will be deleted without warning. Use the function "pandamium:misc/count_filled_inventory_slots" to check how many slots are available before running this function.
 
-setblock 0 0 0 shulker_box
+setblock 0 0 0 yellow_shulker_box
 
 item replace block 0 0 0 container.0 from entity @s armor.chest
 item replace entity @s armor.chest with air

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/vote_shop/purchase/give_caves_and_cliffs_loot_bag.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/vote_shop/purchase/give_caves_and_cliffs_loot_bag.mcfunction
@@ -1,6 +1,6 @@
 # run IN pandamium:staff_world
 
-setblock 0 0 0 shulker_box
+setblock 0 0 0 yellow_shulker_box
 
 # Get random order of items
 tag @e[x=0,y=0,z=0,dx=0,dy=0,dz=0,type=item] add ignore

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/vote_shop/purchase/give_wild_loot_bag.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/vote_shop/purchase/give_wild_loot_bag.mcfunction
@@ -1,6 +1,6 @@
 # run IN pandamium:staff_world
 
-setblock 0 0 0 shulker_box
+setblock 0 0 0 yellow_shulker_box
 
 # Get random order of items
 tag @e[x=0,y=0,z=0,dx=0,dy=0,dz=0,type=item] add ignore


### PR DESCRIPTION
- Switched custom `shulker_box` loot table to a `yellow_shulker_box`
- Removed `SkullOwner.Name` from displayed NBT in containers