### PR TITLE
fixed RTP issues

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/loop.mcfunction
@@ -1,2 +1,3 @@
+scoreboard players add <i> variable 1
 spreadplayers 0 0 0 25000 false @s
-execute at @s if entity @s[x=-5000,y=0,z=-5000,dx=10000,dy=256,dz=10000] in overworld run function pandamium:misc/teleport/random/loop
+execute unless score <i> variable matches 10.. at @s if entity @s[x=-5000,y=-64,z=-5000,dx=10000,dy=384,dz=10000] in overworld run function pandamium:misc/teleport/random/loop

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/loop_successful.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/loop_successful.mcfunction
@@ -1,0 +1,6 @@
+execute store result score <rtp_x> variable run data get entity @s Pos[0]
+execute store result score <rtp_y> variable run data get entity @s Pos[1]
+execute store result score <rtp_z> variable run data get entity @s Pos[2]
+
+execute positioned as @s as @a[tag=teleport.random.player,limit=1] rotated as @s run function pandamium:misc/teleport/main
+tellraw @a[tag=teleport.random.playaer,limit=1] [{"text":"","color":"green"},{"text":"[Info]","color":"blue"}," You have been teleported to ",[{"score":{"name":"<rtp_x>","objective":"variable"},"color":"aqua"}," ",{"score":{"name":"<rtp_y>","objective":"variable"}}," ",{"score":{"name":"<rtp_z>","objective":"variable"}}],"!"]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/main.mcfunction
@@ -1,9 +1,8 @@
-# # Due to a MC bug with detecting hitboxes with 0 size, cannot target a marker entity with [distance=0]
-# tag @s add teleport.random.selected_player
-# execute in pandamium:staff_world run summon marker 0. 0 0. {Tags:["teleport_marker"]}
-# execute in pandamium:staff_world as @e[type=marker,tag=teleport_marker,x=0,y=0,z=0,distance=..0.1] in overworld run function pandamium:misc/teleport/random/teleport_marker
-# tag @s remove teleport.random.selected_player
+# Due to a MC bug with detecting hitboxes with 0 size, cannot target a marker entity with [distance=0]
+tag @s add teleport.random.player
+execute in overworld run summon marker 0. 0 0. {Tags:["teleport.random.marker"]}
+execute in overworld as @e[type=marker,x=0,y=0,z=0,distance=..0.1,tag=teleport.random.marker,limit=1] in overworld run function pandamium:misc/teleport/random/teleport_marker
+tag @s remove teleport.random.player
 
-# execute at @s run playsound block.portal.travel ambient @s
+execute at @s run playsound block.portal.travel ambient @s
 scoreboard players set @s rtp_cooldown 200
-tellraw @s [{"text":"[Info]","color":"dark_red"},{"text":" RTP is currently broken but we are currently trying to fix it. Sorry for the inconvenience.","color":"red"}]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/teleport_marker.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/teleport/random/teleport_marker.mcfunction
@@ -1,10 +1,7 @@
 kill
+
+scoreboard players set <i> variable 0
 function pandamium:misc/teleport/random/loop
 
-execute store result score <rtp_x> variable run data get entity @s Pos[0]
-execute store result score <rtp_y> variable run data get entity @s Pos[1]
-execute store result score <rtp_z> variable run data get entity @s Pos[2]
-
-execute positioned as @s as @a[tag=teleport.random.selected_player] rotated as @s run function pandamium:misc/teleport/main
-
-tellraw @a[tag=teleport.random.selected_player] [{"text":"","color":"green"},{"text":"[Info]","color":"blue"}," You have been teleported to ",[{"score":{"name":"<rtp_x>","objective":"variable"},"color":"aqua"}," ",{"score":{"name":"<rtp_y>","objective":"variable"}}," ",{"score":{"name":"<rtp_z>","objective":"variable"}}],"!"]
+execute if score <i> variable matches 10.. run tellraw @a[tag=teleport.random.player,limit=1] [{"text":"[Info]","color":"dark_red"},{"text":" Iteration limit exceeded! If this issue continues to occur, let a staff member know.","color":"red"}]
+execute unless score <i> variable matches 10.. run function pandamium:misc/teleport/random/loop_successful


### PR DESCRIPTION
- RTP marker should now be summoned and targetted in the overworld rather than the staff world. This fixes an issue introduced in 23w03a
- Added a fallback to the RTP loop. If the marker fails to leave xz= -5000 -5000 to 5000 5000 more than 10 times, it will return an iteration error and stop looping.