### PR TITLE
added sit trigger

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/check_triggers.mcfunction
@@ -11,6 +11,7 @@ execute if score @s clear_inventory = @s clear_inventory unless score @s clear_i
 execute if score @s world_info matches 1.. run function pandamium:triggers/world_info
 execute if score @s guidebook matches 1.. run function pandamium:triggers/guidebook
 execute if score @s leaderboards = @s leaderboards unless score @s leaderboards matches 0 run function pandamium:triggers/leaderboards
+execute if score @s sit = @s sit unless score @s sit matches 0 run function pandamium:triggers/sit
 
 execute if score @s vote matches 1.. run function pandamium:triggers/vote
 execute if score @s vote_shop = @s vote_shop unless score @s vote_shop matches 0 run function pandamium:triggers/vote_shop

--- a/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -30,6 +30,7 @@ execute in the_end as @a[x=0,gamemode=spectator,scores={staff_perms=..1}] run ga
 execute as @a at @s run function pandamium:check_triggers
 
 tp @e[type=#pandamium:remove_at_spawn,predicate=pandamium:in_spawn,tag=!spawn_protected] 0 -1000 0
+execute as @a[predicate=pandamium:riding_aec_seat] on vehicle run data modify entity @s Age set value 0
 
 execute as @a[scores={tpa_request=1..}] run function pandamium:tpa/request_timer
 execute as @a[scores={gift_cooldown=1..}] run function pandamium:misc/gift/cooldown_timer

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit.mcfunction
@@ -1,0 +1,7 @@
+execute positioned ~ ~-0.25 ~ if block ~ ~ ~ #stairs[half=bottom,facing=north] align xyz run tp ~0.5 ~0.5 ~0.7
+execute positioned ~ ~-0.25 ~ if block ~ ~ ~ #stairs[half=bottom,facing=east] align xyz run tp ~0.3 ~0.5 ~0.5
+execute positioned ~ ~-0.25 ~ if block ~ ~ ~ #stairs[half=bottom,facing=south] align xyz run tp ~0.5 ~0.5 ~0.3
+execute positioned ~ ~-0.25 ~ if block ~ ~ ~ #stairs[half=bottom,facing=west] align xyz run tp ~0.7 ~0.5 ~0.5
+
+execute positioned as @s run summon area_effect_cloud ~ ~-0.5 ~ {Tags:["seat"],Duration:40,Radius:0f,Particle:"block air",CustomName:'{"text":"seat","color":"gray"}'}
+execute positioned as @s positioned ~ ~-0.5 ~ run ride @s mount @e[type=area_effect_cloud,distance=..0.1,tag=seat,limit=1,sort=nearest]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/on_join.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/on_join.mcfunction
@@ -43,6 +43,7 @@ scoreboard players enable @s gift
 scoreboard players enable @s leaderboards
 scoreboard players enable @s save_mob.spawn
 scoreboard players enable @s rtp
+scoreboard players enable @s sit
 
 execute if score @s parkour.checkpoint matches 0.. run scoreboard players enable @s parkour.quit
 execute if score @s parkour.checkpoint matches 0.. run scoreboard players enable @s parkour.restart

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -26,6 +26,7 @@ scoreboard objectives add enderman_farm trigger {"text":"enderman_farm","color":
 scoreboard objectives add respawn trigger {"text":"respawn","color":"gray"}
 scoreboard objectives add options trigger {"text":"options","color":"gray"}
 scoreboard objectives add rtp trigger {"text":"rtp","color":"gray"}
+scoreboard objectives add sit trigger {"text":"sit","color":"gray"}
 
 scoreboard objectives add vote trigger {"text":"vote","color":"gray"}
 scoreboard objectives add vote_shop trigger {"text":"vote_shop","color":"gray"}
@@ -233,6 +234,7 @@ scoreboard players reset * parkour.quit
 scoreboard players reset * parkour.restart
 scoreboard players reset * save_mob.spawn
 scoreboard players reset * rtp
+scoreboard players reset * sit
 
 scoreboard players reset * particles
 scoreboard players reset * clear_inventory

--- a/snapshot_pandamium_datapack/data/pandamium/functions/triggers/sit.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/triggers/sit.mcfunction
@@ -1,0 +1,7 @@
+scoreboard players set <returned> variable 0
+execute if predicate pandamium:riding_entity store success score <returned> variable run tellraw @s [{"text":"[Sit]","color":"dark_red"},{"text":" You are already sitting!","color":"red"}]
+execute if score <returned> variable matches 0 if data entity @s {OnGround:0b} store success score <returned> variable run tellraw @s [{"text":"[Sit]","color":"dark_red"},{"text":" You cannot sit currently!","color":"red"}]
+execute if score <returned> variable matches 0 run function pandamium:misc/sit
+
+scoreboard players reset @s sit
+scoreboard players enable @s sit

--- a/snapshot_pandamium_datapack/data/pandamium/predicates/riding_aec_seat.json
+++ b/snapshot_pandamium_datapack/data/pandamium/predicates/riding_aec_seat.json
@@ -1,0 +1,10 @@
+{
+	"condition": "minecraft:entity_properties",
+	"entity": "this",
+	"predicate": {
+		"vehicle": {
+			"type": "minecraft:area_effect_cloud",
+			"nbt": "{Tags:['seat']}"
+		}
+	}
+}


### PR DESCRIPTION
- players can run `/trigger sit` to sit down wherever they are
- If they run `/trigger sit` while standing on a stair block with its slab-half down, they will be repositioned as if they are sitting on it like a chair