### PR TITLE
changed detect/sneak_to_sit value range

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/advancements/detect/sneak_to_sit.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/detect/sneak_to_sit.json
@@ -19,7 +19,7 @@
 								"entity": "this",
 								"scores": {
 									"detect.sneak_to_sit_time": {
-										"max": -1
+										"max": -1073741825
 									}
 								}
 							},


### PR DESCRIPTION
changed `detect.sneak_to_sit_time` range to be below `-1073741825` in order to run the function, rather than below `-1`because any values from `-1073741824` to `-1` now represent the player being sat on the ground.