### PR TITLE
Improvements to attack indicator and containers enchantment reader

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/advancements/detect/hurt_entity.json
+++ b/snapshot_pandamium_datapack/data/pandamium/advancements/detect/hurt_entity.json
@@ -5,6 +5,6 @@
 			}
 		},
 	"rewards": {
-		"function": "pandamium:misc/attack_indicator/hurt_entity"
+		"function": "pandamium:misc/detect/hurt_entity"
 	}
 }

--- a/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/enchantments/iter.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/enchantments/iter.mcfunction
@@ -1,4 +1,6 @@
-data modify block 0 0 0 Text1 set value '[{"nbt":"Text1","block":"0 0 0","interpret":true},"\\n",{"nbt":"item.tag.Enchantments[0].id","storage":"pandamium:containers","color":"green"}," ",{"nbt":"item.tag.Enchantments[0].lvl","storage":"pandamium:containers","color":"gold"}]'
+execute store result score <level> variable run data get storage pandamium:containers item.tag.Enchantments[0].lvl
+data modify block 0 0 0 Text1 set value '[{"nbt":"item.tag.Enchantments[0].id","storage":"pandamium:containers","color":"green"}," ",{"score":{"name":"<level>","objective":"variable"},"color":"gold"}]'
+data modify storage pandamium:containers enchantments append from block 0 0 0 Text1
 
 data remove storage pandamium:containers item.tag.Enchantments[0]
 execute if data storage pandamium:containers item.tag.Enchantments[0] run function pandamium:containers/run/enchantments/iter

--- a/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/enchantments/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/enchantments/main.mcfunction
@@ -1,8 +1,6 @@
-execute in pandamium:staff_world run setblock 0 0 0 air
+execute in pandamium:staff_world run setblock 0 0 0 oak_sign
+data modify storage pandamium:containers enchantments set value []
+execute in pandamium:staff_world run function pandamium:containers/run/enchantments/iter
 
-execute in pandamium:staff_world run setblock 0 0 0 oak_sign{Text1:'[{"nbt":"item.tag.Enchantments[0].id","storage":"pandamium:containers","color":"green"}," ",{"nbt":"item.tag.Enchantments[0].lvl","storage":"pandamium:containers","color":"gold"}]'}
-data remove storage pandamium:containers item.tag.Enchantments[0]
-execute if data storage pandamium:containers item.tag.Enchantments[0] in pandamium:staff_world run function pandamium:containers/run/enchantments/iter
-
-execute if data storage pandamium:containers {item:{id:'minecraft:enchanted_book'}} in pandamium:staff_world run tellraw @s [{"text":"└StoredEnchantments: ","color":"aqua"},{"text":"[Stored Enchantments]","color":"dark_purple","hoverEvent":{"action":"show_text","value":[{"nbt":"Text1","block":"0 0 0","interpret":true}]}}]
-execute unless data storage pandamium:containers {item:{id:'minecraft:enchanted_book'}} in pandamium:staff_world run tellraw @s [{"text":"└Enchantments: ","color":"aqua"},{"text":"[Enchantments]","color":"dark_purple","hoverEvent":{"action":"show_text","value":[{"nbt":"Text1","block":"0 0 0","interpret":true}]}}]
+execute if data storage pandamium:containers {item:{id:'minecraft:enchanted_book'}} in pandamium:staff_world run tellraw @s [{"text":"└StoredEnchantments: ","color":"aqua"},{"text":"[Stored Enchantments]","color":"dark_purple","hoverEvent":{"action":"show_text","value":[{"nbt":"enchantments[]","storage":"pandamium:containers","interpret":true,"separator":"\n"}]}}]
+execute unless data storage pandamium:containers {item:{id:'minecraft:enchanted_book'}} in pandamium:staff_world run tellraw @s [{"text":"└Enchantments: ","color":"aqua"},{"text":"[Enchantments]","color":"dark_purple","hoverEvent":{"action":"show_text","value":[{"nbt":"enchantments[]","storage":"pandamium:containers","interpret":true,"separator":"\n"}]}}]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/nbt.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/containers/run/nbt.mcfunction
@@ -30,10 +30,10 @@ execute if data storage pandamium:containers item.tag.LodestonePos run tellraw @
 execute if data storage pandamium:containers item.tag.Potion run tellraw @s [{"text":"└Potion: ","color":"aqua"},{"nbt":"item.tag.Potion","storage":"pandamium:containers","color":"green"}]
 execute if data storage pandamium:containers item.tag.title if data storage pandamium:containers item.tag.author run tellraw @s [{"text":"└Book: ","color":"aqua"},{"nbt":"item.tag.title","storage":"pandamium:containers","color":"green"}," by ",{"nbt":"item.tag.author","storage":"pandamium:containers","color":"green"}]
 
-execute if data storage pandamium:containers item.tag.StoredEnchantments run data modify storage pandamium:containers item.tag.Enchantments set from storage pandamium:containers item.tag.StoredEnchantments
-execute if data storage pandamium:containers item.tag.Enchantments run function pandamium:containers/run/enchantments/main
+data modify storage pandamium:containers item.tag.Enchantments append from storage pandamium:containers item.tag.StoredEnchantments[]
+execute if data storage pandamium:containers item.tag.Enchantments[0] run function pandamium:containers/run/enchantments/main
 
-execute if data storage pandamium:containers item.tag.BlockEntityTag.Items run data modify storage pandamium:containers item.tag.Items set from storage pandamium:containers item.tag.BlockEntityTag.Items
+data modify storage pandamium:containers item.tag.Items append from storage pandamium:containers item.tag.BlockEntityTag.Items[]
 execute if data storage pandamium:containers item.tag.Items[0] run function pandamium:containers/run/inspect/prompt_items
 
 execute if data storage pandamium:containers item.tag.pages[0] run function pandamium:containers/run/inspect/prompt_pages

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_entity.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_entity.mcfunction
@@ -1,8 +1,0 @@
-# rounds Health to 2d.p., as [/data] always returns an integer
-execute store result storage pandamium:temp Health float 0.01 run data get entity @s Health 100
-
-execute store result score <max_health> variable run attribute @s generic.max_health get
-
-scoreboard players set <hurt_shielded_entity> variable 0
-execute store success score <hurt_shielded_entity> variable if entity @s[type=phantom,team=dragon_fight] if data entity @s Passengers run title @p[tag=player] actionbar [{"selector":"@s"},{"text":" is shielded by its crystal","color":"yellow"}]
-execute if score <hurt_shielded_entity> variable matches 0 run title @p[tag=player] actionbar ["",{"selector":"@s"}," ",{"nbt":"Health","storage":"pandamium:temp","color":"yellow"},"/",{"score":{"name":"<max_health>","objective":"variable"},"color":"yellow"}]

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_potential_entity.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/as_potential_entity.mcfunction
@@ -1,0 +1,8 @@
+# in pandamium:staff_world
+
+# rounds Health to 2d.p., as [/data] always returns an integer
+execute store result storage pandamium:temp attack_indicator.health float 0.01 run data get storage pandamium:temp nbt.Health 100
+execute store result score <max_health> variable run attribute @s generic.max_health get
+
+item modify block 0 0 0 container.0 pandamium:attack_indicator/actionbar_text
+data modify storage pandamium:temp attack_indicator.targets append from block 0 0 0 Items[0].tag.display.Name

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/check_entity.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/check_entity.mcfunction
@@ -1,0 +1,4 @@
+scoreboard players set <hit> variable 0
+execute on attacker if entity @s[tag=player] run scoreboard players set <hit> variable 1
+execute if score <hit> variable matches 1 run data modify storage pandamium:temp nbt set from entity @s
+execute if score <hit> variable matches 1 if data storage pandamium:temp nbt{HurtTime:10s} in pandamium:staff_world run function pandamium:misc/attack_indicator/as_potential_entity

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/hurt_entity.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/attack_indicator/hurt_entity.mcfunction
@@ -1,5 +1,7 @@
-advancement revoke @s only pandamium:detect/hurt_entity
-
+data modify storage pandamium:temp attack_indicator.targets set value []
+execute in pandamium:staff_world run setblock 0 0 0 barrel
+execute in pandamium:staff_world run item replace block 0 0 0 container.0 with stone
 tag @s add player
-execute unless score @s disable_attack_indicator matches 1 at @s as @e[limit=1,sort=nearest,distance=..64,tag=!player,nbt={HurtTime:10s}] run function pandamium:misc/attack_indicator/as_entity
+execute unless score @s disable_attack_indicator matches 1 at @s as @e[distance=..64,tag=!player,sort=furthest] run function pandamium:misc/attack_indicator/check_entity
 tag @s remove player
+title @s actionbar {"nbt":"attack_indicator.targets[]","storage":"pandamium:temp","interpret":true,"separator":{"text":" | ","color":"gray"}}

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/hurt_entity.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/hurt_entity.mcfunction
@@ -1,0 +1,3 @@
+function pandamium:misc/attack_indicator/hurt_entity
+
+advancement revoke @s only pandamium:detect/hurt_entity

--- a/snapshot_pandamium_datapack/data/pandamium/item_modifiers/attack_indicator/actionbar_text.json
+++ b/snapshot_pandamium_datapack/data/pandamium/item_modifiers/attack_indicator/actionbar_text.json
@@ -1,0 +1,74 @@
+[
+	{
+		"function": "minecraft:set_name",
+		"entity": "this",
+		"name": [
+			{
+				"text": "",
+				"color": "yellow"
+			},
+			{
+				"selector": "@s",
+				"bold": true
+			},
+			" ",
+			{
+				"nbt": "attack_indicator.health",
+				"storage": "pandamium:temp"
+			},
+			"/",
+			{
+				"score": {
+					"name": "<max_health>",
+					"objective": "variable"
+				}
+			}
+		]
+	},
+	{
+		"function": "minecraft:set_name",
+		"entity": "this",
+		"name": [
+			{
+				"text": "",
+				"color": "yellow"
+			},
+			{
+				"selector": "@s",
+				"bold": true
+			},
+			" is ",
+			{
+				"text": "invulnerable",
+				"italic": true
+			}
+		],
+		"conditions": [
+			{
+				"condition": "minecraft:alternative",
+				"terms": [
+					{
+						"condition": "minecraft:entity_properties",
+						"entity": "this",
+						"predicate": {
+							"effects": {
+								"minecraft:resistance": {
+									"amplifier": {
+										"min": 4
+									}
+								}
+							}
+						}
+					},
+					{
+						"condition": "minecraft:entity_properties",
+						"entity": "this",
+						"predicate": {
+							"nbt": "{Invulnerable:1b}"
+						}
+					}
+				]
+			}
+		]
+	}
+]


### PR DESCRIPTION
- Attack indicator now more efficiently selects the entities which the player attacked (a rare false-positive case still can occur but it's much better and more efficient than last time)
- If multiple entities are hit in the same tick, they will all be displayed in the actionbar, separated by `|`s
- The _containers_ enchantment reader is now much less stupidly programmed (and more efficient)