### PR TITLE
improvements to disable_keep_inventory

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/die.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/die.mcfunction
@@ -1,4 +1,4 @@
 execute if score @s death_particles matches 1.. if entity @s[gamemode=!spectator] unless score @s hidden matches 1.. at @s if entity @a[distance=..64,limit=1] run function pandamium:misc/particles/death_event
-execute if score @s disable_keep_inventory matches 1 if entity @s[predicate=!pandamium:in_dimension/staff_world,predicate=!pandamium:in_spawn,gamemode=survival] in pandamium:staff_world if blocks 0 0 0 0 0 0 0 0 0 all run function pandamium:misc/drop_inventory_items
+execute if score @s disable_keep_inventory matches 1 if entity @s[predicate=!pandamium:in_dimension/staff_world,predicate=!pandamium:in_spawn,gamemode=survival] run function pandamium:misc/drop_inventory/main
 
 scoreboard players reset @s detect.die

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/clear_items.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/clear_items.mcfunction
@@ -1,0 +1,5 @@
+scoreboard players set <dropped_items> variable 1
+
+clear @s
+xp set @s 0 levels
+xp set @s 0 points

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/drop_items.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/drop_items.mcfunction
@@ -1,6 +1,7 @@
 # run IN pandamium:staff_world
+scoreboard players set <dropped_items> variable 1
 
-tag @e[type=item,x=0,y=0,z=0,dx=0] add ignore
+kill @e[type=item,x=0,y=0,z=0,dx=0]
 
 data modify storage pandamium:temp nbt set from entity @s
 
@@ -27,8 +28,7 @@ item replace block 0 0 0 container.13 from entity @s armor.feet
 data remove block 0 0 0 Items[{tag:{Enchantments:[{id:"minecraft:vanishing_curse"}]}}]
 loot spawn 0 0 0 mine 0 0 0 air{drop_contents:1b}
 
-tp @e[type=item,x=0,y=0,z=0,dx=0,tag=!ignore] @s
-tag @e[type=item,x=0,y=0,z=0,dx=0] remove ignore
+tp @e[type=item,x=0,y=0,z=0,dx=0] @s
 
 loot replace entity @s container.0 36 loot empty
 item replace entity @s armor.head with air

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/drop_items.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/drop_items.mcfunction
@@ -1,34 +1,34 @@
 # run IN pandamium:staff_world
 scoreboard players set <dropped_items> variable 1
 
-kill @e[type=item,x=0,y=0,z=0,dx=0]
+kill @e[type=item,distance=..0.01]
 
 data modify storage pandamium:temp nbt set from entity @s
 
-setblock 0 0 0 yellow_shulker_box
-data modify block 0 0 0 Items set from storage pandamium:temp nbt.Inventory
-data remove block 0 0 0 Items[{tag:{Enchantments:[{id:"minecraft:vanishing_curse"}]}}]
-loot spawn 0 0 0 mine 0 0 0 air{drop_contents:1b}
+setblock ~ ~ ~ yellow_shulker_box
+data modify block ~ ~ ~ Items set from storage pandamium:temp nbt.Inventory
+data remove block ~ ~ ~ Items[{tag:{Enchantments:[{id:"minecraft:vanishing_curse"}]}}]
+loot spawn ~ ~ ~ mine ~ ~ ~ air{drop_contents:1b}
 
-loot replace block 0 0 0 container.0 27 loot empty
-item replace block 0 0 0 container.0 from entity @s container.27
-item replace block 0 0 0 container.1 from entity @s container.28
-item replace block 0 0 0 container.2 from entity @s container.29
-item replace block 0 0 0 container.3 from entity @s container.30
-item replace block 0 0 0 container.4 from entity @s container.31
-item replace block 0 0 0 container.5 from entity @s container.32
-item replace block 0 0 0 container.6 from entity @s container.33
-item replace block 0 0 0 container.7 from entity @s container.34
-item replace block 0 0 0 container.8 from entity @s container.35
-item replace block 0 0 0 container.9 from entity @s weapon.offhand
-item replace block 0 0 0 container.10 from entity @s armor.head
-item replace block 0 0 0 container.11 from entity @s armor.chest
-item replace block 0 0 0 container.12 from entity @s armor.legs
-item replace block 0 0 0 container.13 from entity @s armor.feet
-data remove block 0 0 0 Items[{tag:{Enchantments:[{id:"minecraft:vanishing_curse"}]}}]
-loot spawn 0 0 0 mine 0 0 0 air{drop_contents:1b}
+loot replace block ~ ~ ~ container.0 27 loot empty
+item replace block ~ ~ ~ container.0 from entity @s container.27
+item replace block ~ ~ ~ container.1 from entity @s container.28
+item replace block ~ ~ ~ container.2 from entity @s container.29
+item replace block ~ ~ ~ container.3 from entity @s container.30
+item replace block ~ ~ ~ container.4 from entity @s container.31
+item replace block ~ ~ ~ container.5 from entity @s container.32
+item replace block ~ ~ ~ container.6 from entity @s container.33
+item replace block ~ ~ ~ container.7 from entity @s container.34
+item replace block ~ ~ ~ container.8 from entity @s container.35
+item replace block ~ ~ ~ container.9 from entity @s weapon.offhand
+item replace block ~ ~ ~ container.10 from entity @s armor.head
+item replace block ~ ~ ~ container.11 from entity @s armor.chest
+item replace block ~ ~ ~ container.12 from entity @s armor.legs
+item replace block ~ ~ ~ container.13 from entity @s armor.feet
+data remove block ~ ~ ~ Items[{tag:{Enchantments:[{id:"minecraft:vanishing_curse"}]}}]
+loot spawn ~ ~ ~ mine ~ ~ ~ air{drop_contents:1b}
 
-tp @e[type=item,x=0,y=0,z=0,dx=0] @s
+tp @e[type=item,distance=..0.01] @s
 
 loot replace entity @s container.0 36 loot empty
 item replace entity @s armor.head with air

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/main.mcfunction
@@ -1,3 +1,3 @@
 scoreboard players set <dropped_items> variable 0
 execute at @s if predicate pandamium:can_take_void_damage run function pandamium:misc/drop_inventory/clear_items
-execute if score <dropped_items> variable matches 0 in pandamium:staff_world if loaded 0 0 0 run function pandamium:misc/drop_inventory/drop_items
+execute if score <dropped_items> variable matches 0 at @s positioned 29999999 0 29999999 if loaded ~ ~ ~ run function pandamium:misc/drop_inventory/drop_items

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/drop_inventory/main.mcfunction
@@ -1,0 +1,3 @@
+scoreboard players set <dropped_items> variable 0
+execute at @s if predicate pandamium:can_take_void_damage run function pandamium:misc/drop_inventory/clear_items
+execute if score <dropped_items> variable matches 0 in pandamium:staff_world if loaded 0 0 0 run function pandamium:misc/drop_inventory/drop_items


### PR DESCRIPTION
- if the player is in the void, the items and xp simply get cleared rather than dropped
- fix for desync due to interdimensional teleport of item entities