### PR TITLE
corrected stairs sitting hitbox position

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit/do_sit.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit/do_sit.mcfunction
@@ -1,5 +1,3 @@
-execute positioned ~ ~-0.01 ~ if block ~ ~ ~ #stairs[half=bottom] if block ~ ~1 ~ #pandamium:no_solid_collision if block ~ ~2 ~ #pandamium:no_solid_collision run function pandamium:misc/sit/reposition_on_stairs
-
 tag @s add sit
 execute positioned as @s positioned ~ ~-0.495 ~ rotated as @s summon area_effect_cloud run function pandamium:misc/sit/as_seat_entity
 tag @s remove sit

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit/main.mcfunction
@@ -1,3 +1,4 @@
 scoreboard players set <sat> variable 0
 execute unless predicate pandamium:can_sit run function pandamium:misc/sit/reposition_if_on_stairs_edge
+execute positioned as @s if predicate pandamium:can_sit positioned ~ ~-0.01 ~ if block ~ ~ ~ #stairs[half=bottom] if block ~ ~1 ~ #pandamium:no_solid_collision if block ~ ~2 ~ #pandamium:no_solid_collision run function pandamium:misc/sit/reposition_on_stairs
 execute positioned as @s if predicate pandamium:can_sit store success score <sat> variable run function pandamium:misc/sit/do_sit

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit/reposition_on_stairs.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/sit/reposition_on_stairs.mcfunction
@@ -1,4 +1,4 @@
-execute if block ~ ~ ~ #stairs[half=bottom,facing=north] align xyz run tp ~0.5 ~0.5 ~0.7
-execute if block ~ ~ ~ #stairs[half=bottom,facing=east] align xyz run tp ~0.3 ~0.5 ~0.5
-execute if block ~ ~ ~ #stairs[half=bottom,facing=south] align xyz run tp ~0.5 ~0.5 ~0.3
-execute if block ~ ~ ~ #stairs[half=bottom,facing=west] align xyz run tp ~0.7 ~0.5 ~0.5
+execute if block ~ ~ ~ #stairs[half=bottom,facing=north] align xyz run tp ~0.5 ~0.5 ~0.8
+execute if block ~ ~ ~ #stairs[half=bottom,facing=east] align xyz run tp ~0.2 ~0.5 ~0.5
+execute if block ~ ~ ~ #stairs[half=bottom,facing=south] align xyz run tp ~0.5 ~0.5 ~0.2
+execute if block ~ ~ ~ #stairs[half=bottom,facing=west] align xyz run tp ~0.8 ~0.5 ~0.5


### PR DESCRIPTION
- Moved the stairs repositioning command to `sit/main` so that `sit/do_sit` **always** forces the player to sit where they are.
- Sitting on a stairs block now positions the player exactly where their hitbox would collide with the back piece. This should prevent the player from being able to noclip through the block backwards when they stand up.