### PR TITLE
removed empty leaderboard lines

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/leaderboards/hologram/monthly_playtime/generate/iter.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/leaderboards/hologram/monthly_playtime/generate/iter.mcfunction
@@ -4,7 +4,7 @@ execute store result score <decimal> variable run data get storage pandamium:tem
 execute if score <decimal> variable matches 10.. run data modify block 0 0 0 Text1 set value '[{"text":"(","color":"aqua"},{"score":{"name":"<n>","objective":"variable"},"bold":true},") ",{"nbt":"hologram.leaderboard[0].display_name","storage":"pandamium:temp","interpret":true}," - ",[{"nbt":"hologram.leaderboard[0].time[3]","storage":"pandamium:temp","interpret":true,"color":"green","bold":true},".",{"score":{"name":"<decimal>","objective":"variable"}}]]'
 execute if score <decimal> variable matches 0..9 run data modify block 0 0 0 Text1 set value '[{"text":"(","color":"aqua"},{"score":{"name":"<n>","objective":"variable"},"bold":true},") ",{"nbt":"hologram.leaderboard[0].display_name","storage":"pandamium:temp","interpret":true}," - ",[{"nbt":"hologram.leaderboard[0].time[3]","storage":"pandamium:temp","interpret":true,"color":"green","bold":true},".0",{"score":{"name":"<decimal>","objective":"variable"}}]]'
 
-data modify storage pandamium:temp hologram.lines append from block 0 0 0 Text1
+execute if data storage pandamium:temp hologram.leaderboard[0].id run data modify storage pandamium:temp hologram.lines append from block 0 0 0 Text1
 
 data remove storage pandamium:temp hologram.leaderboard[0]
 execute if score <n> variable < <max> variable if data storage pandamium:temp hologram.leaderboard[0] run function pandamium:misc/leaderboards/hologram/monthly_playtime/generate/iter

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/leaderboards/hologram/monthly_votes/generate/iter.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/leaderboards/hologram/monthly_votes/generate/iter.mcfunction
@@ -2,7 +2,7 @@ scoreboard players add <n> variable 1
 
 data modify block 0 0 0 Text1 set value '[{"text":"(","color":"aqua"},{"score":{"name":"<n>","objective":"variable"},"bold":true},") ",{"nbt":"hologram.leaderboard[0].display_name","storage":"pandamium:temp","interpret":true}," - ",[{"nbt":"hologram.leaderboard[0].value","storage":"pandamium:temp","interpret":true,"color":"green","bold":true}]]'
 
-data modify storage pandamium:temp hologram.lines append from block 0 0 0 Text1
+execute if data storage pandamium:temp hologram.leaderboard[0].id run data modify storage pandamium:temp hologram.lines append from block 0 0 0 Text1
 
 data remove storage pandamium:temp hologram.leaderboard[0]
 execute if score <n> variable < <max> variable if data storage pandamium:temp hologram.leaderboard[0] run function pandamium:misc/leaderboards/hologram/monthly_votes/generate/iter


### PR DESCRIPTION
- Unset leaderboard entries (ones where `id` is not set) will not be added to the leaderboard hologram
Before: 
![image](https://user-images.githubusercontent.com/16517352/222246710-a784b680-51ce-4a8e-a1e5-ba108f71829c.png)
