### PR TITLE
added spawn platform bedrock and block placing prevention

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/change_dimension.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/detect/change_dimension.mcfunction
@@ -1,3 +1,5 @@
+execute in the_end positioned 100 48 0 if entity @s[distance=..1] run function pandamium:misc/queue/append/teleport_to_end_platform
+
 execute if predicate pandamium:in_dimension/the_nether run scoreboard players set @s in_dimension -1
 execute if predicate pandamium:in_dimension/overworld run scoreboard players set @s in_dimension 0
 execute if predicate pandamium:in_dimension/the_end run scoreboard players set @s in_dimension 1

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/actions/teleport_to_end_platform.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/actions/teleport_to_end_platform.mcfunction
@@ -1,0 +1,11 @@
+#{
+#	action: "teleport_to_end_platform",
+#	player: INT
+#}
+
+execute in the_end unless loaded 100 48 0 run scoreboard players set <wait> variable 1
+
+execute if score <wait> variable matches 0 in the_end run setblock 100 48 0 bedrock
+execute if score <wait> variable matches 0 in the_end run fill 98 49 -2 102 51 2 moving_piston
+execute if score <wait> variable matches 0 if data storage pandamium:queue this.player store result score <id> variable run data get storage pandamium:queue this.player
+execute if score <wait> variable matches 0 if data storage pandamium:queue this.player as @a if score @s id = <id> variable in the_end run tp @s 100 49 0

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/append/teleport_to_end_platform.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/append/teleport_to_end_platform.mcfunction
@@ -1,0 +1,3 @@
+data modify storage pandamium:temp queue.entry set value {action:"teleport_to_end_platform",wait:0}
+execute store result storage pandamium:temp queue.entry.player int 1 run scoreboard players get @s id
+data modify storage pandamium:queue queue append from storage pandamium:temp queue.entry

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/iter.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/iter.mcfunction
@@ -1,6 +1,8 @@
-data modify storage pandamium:queue this set from storage pandamium:queue queue[0]
-execute if data storage pandamium:queue this{action:"teleport_player"} run function pandamium:misc/queue/actions/teleport_player
-execute if data storage pandamium:queue this{action:"parkour/trigger_node"} run function pandamium:misc/queue/actions/parkour/trigger_node
+data modify storage pandamium:queue this set from storage pandamium:temp queue.copy[-1]
 
-data remove storage pandamium:queue queue[0]
-execute if data storage pandamium:queue queue[0] run function pandamium:misc/queue/iter
+execute store result score <wait> variable run data get storage pandamium:queue this.wait
+execute unless score <wait> variable matches 1.. run function pandamium:misc/queue/run
+execute if score <wait> variable matches 1.. run function pandamium:misc/queue/recycle
+
+data remove storage pandamium:temp queue.copy[-1]
+execute if data storage pandamium:temp queue.copy[-1] run function pandamium:misc/queue/iter

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/main.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/main.mcfunction
@@ -1,4 +1,5 @@
-data modify storage pandamium:queue carry set value []
-execute if data storage pandamium:queue queue[0] run function pandamium:misc/queue/iter
-execute if data storage pandamium:queue carry[0] run data modify storage pandamium:queue queue append from storage pandamium:queue carry[]
-execute if data storage pandamium:queue carry[0] run data modify storage pandamium:queue carry set value []
+data modify storage pandamium:temp queue.copy set value []
+data modify storage pandamium:temp queue.copy prepend from storage pandamium:queue queue[]
+data modify storage pandamium:queue queue set value []
+
+execute if data storage pandamium:temp queue.copy[0] run function pandamium:misc/queue/iter

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/recycle.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/recycle.mcfunction
@@ -1,0 +1,2 @@
+execute store result storage pandamium:queue this.wait int 1 run scoreboard players remove <wait> variable 1
+data modify storage pandamium:queue queue append from storage pandamium:queue this

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/run.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/queue/run.mcfunction
@@ -1,0 +1,3 @@
+execute if data storage pandamium:queue this{action:"teleport_player"} run function pandamium:misc/queue/actions/teleport_player
+execute if data storage pandamium:queue this{action:"parkour/trigger_node"} run function pandamium:misc/queue/actions/parkour/trigger_node
+execute if data storage pandamium:queue this{action:"teleport_to_end_platform"} run function pandamium:misc/queue/actions/teleport_to_end_platform

--- a/snapshot_pandamium_datapack/data/pandamium/functions/tick_loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/tick_loop.mcfunction
@@ -1,4 +1,6 @@
-execute if data storage pandamium:queue queue[0] run function pandamium:misc/queue/iter
+# Runs **after** all scheduled functions (including the main loop)
+
+execute if data storage pandamium:queue queue[0] run function pandamium:misc/queue/main
 
 execute as @a[scores={detect.die=1..}] run function pandamium:misc/detect/die
 


### PR DESCRIPTION
- going through the end portal (or warping directly to the end platform) will place a bedrock block beneath your feet, and fill the platform air space with `moving_piston` blocks so that players cannot place blocks on the platform (preventing them from possibly being accidentally destroyed)