### PR TITLE
Added playtime pause while AFK

### DIFF
--- a/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/main_loop.mcfunction
@@ -57,7 +57,7 @@ execute as @a[scores={suspicious_ip=1}] run function pandamium:misc/flagged_ip
 execute as @a[scores={hidden=1..}] run function pandamium:misc/hide/loop
 function pandamium:misc/parkour/loop
 function pandamium:misc/particles/main_loop
-execute as @a[scores={track_afk=1}] run function pandamium:misc/afk_playtime
+function pandamium:misc/afk/loop
 
 scoreboard players add <ticks_since_monthly_leaderboard_holograms_updated> global 5
 execute if score <ticks_since_monthly_leaderboard_holograms_updated> global matches 1200.. positioned -7.631728 91.0 8.631728 if entity @a[distance=..15,limit=1] run function pandamium:misc/leaderboards/hologram/update_monthly_leaderboard_holograms

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/as_marker.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/as_marker.mcfunction
@@ -1,0 +1,2 @@
+kill
+execute at @a run function pandamium:misc/afk/at_player

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/as_player.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/as_player.mcfunction
@@ -1,0 +1,11 @@
+execute store result score <x> variable run data get storage pandamium:temp afk.pos[0] 10
+execute store result score <y> variable run data get storage pandamium:temp afk.pos[1] 10
+execute store result score <z> variable run data get storage pandamium:temp afk.pos[2] 10
+
+scoreboard players set <moved> variable 1
+execute if score @s afk.last_x = <x> variable if score @s afk.last_y = <y> variable if score @s afk.last_z = <z> variable run scoreboard players set <moved> variable 0
+execute if score <moved> variable matches 1 run scoreboard players set @s afk.time -2400
+
+scoreboard players operation @s afk.last_x = <x> variable
+scoreboard players operation @s afk.last_y = <y> variable
+scoreboard players operation @s afk.last_z = <z> variable

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/as_player.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/as_player.mcfunction
@@ -1,11 +1,9 @@
-execute store result score <x> variable run data get storage pandamium:temp afk.pos[0] 10
-execute store result score <y> variable run data get storage pandamium:temp afk.pos[1] 10
-execute store result score <z> variable run data get storage pandamium:temp afk.pos[2] 10
+execute store result score <r0> variable run data get storage pandamium:temp afk.rotation[0]
+execute store result score <r1> variable run data get storage pandamium:temp afk.rotation[1]
 
 scoreboard players set <moved> variable 1
-execute if score @s afk.last_x = <x> variable if score @s afk.last_y = <y> variable if score @s afk.last_z = <z> variable run scoreboard players set <moved> variable 0
+execute if score @s afk.last_r0 = <r0> variable if score @s afk.last_r1 = <r1> variable run scoreboard players set <moved> variable 0
 execute if score <moved> variable matches 1 run scoreboard players set @s afk.time -2400
 
-scoreboard players operation @s afk.last_x = <x> variable
-scoreboard players operation @s afk.last_y = <y> variable
-scoreboard players operation @s afk.last_z = <z> variable
+scoreboard players operation @s afk.last_r0 = <r0> variable
+scoreboard players operation @s afk.last_r1 = <r1> variable

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/at_player.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/at_player.mcfunction
@@ -1,3 +1,3 @@
-execute in pandamium:staff_world run tp ~ ~ ~
-data modify storage pandamium:temp afk.pos set from entity @s Pos
+execute in pandamium:staff_world run tp @s 0 0 0 ~ ~
+data modify storage pandamium:temp afk.rotation set from entity @s Rotation
 execute as @p run function pandamium:misc/afk/as_player

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/at_player.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/at_player.mcfunction
@@ -1,0 +1,3 @@
+execute in pandamium:staff_world run tp ~ ~ ~
+data modify storage pandamium:temp afk.pos set from entity @s Pos
+execute as @p run function pandamium:misc/afk/as_player

--- a/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/loop.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/misc/afk/loop.mcfunction
@@ -1,0 +1,4 @@
+execute in pandamium:staff_world positioned 0 0 0 summon marker run function pandamium:misc/afk/as_marker
+
+scoreboard players remove @a[scores={afk.time=1..}] playtime_ticks 5
+scoreboard players remove @a[scores={afk.time=1..}] monthly_playtime_ticks 5

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -178,10 +178,10 @@ scoreboard objectives add spawnpoint_y dummy
 scoreboard objectives add spawnpoint_z dummy
 scoreboard objectives add spawnpoint_d dummy
 
-scoreboard objectives add track_afk dummy
-scoreboard objectives add afk_last_x dummy
-scoreboard objectives add afk_last_z dummy
-scoreboard objectives add afk_time dummy
+scoreboard objectives add afk.last_x dummy
+scoreboard objectives add afk.last_y dummy
+scoreboard objectives add afk.last_z dummy
+scoreboard objectives add afk.time custom:play_time
 
 # On Join (set to 1 to do something when a player joins)
 scoreboard objectives add on_join.take_items dummy

--- a/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
+++ b/snapshot_pandamium_datapack/data/pandamium/functions/startup.mcfunction
@@ -178,9 +178,8 @@ scoreboard objectives add spawnpoint_y dummy
 scoreboard objectives add spawnpoint_z dummy
 scoreboard objectives add spawnpoint_d dummy
 
-scoreboard objectives add afk.last_x dummy
-scoreboard objectives add afk.last_y dummy
-scoreboard objectives add afk.last_z dummy
+scoreboard objectives add afk.last_r0 dummy
+scoreboard objectives add afk.last_r1 dummy
 scoreboard objectives add afk.time custom:play_time
 
 # On Join (set to 1 to do something when a player joins)
@@ -203,8 +202,8 @@ scoreboard objectives add parkour.timer_ticks dummy
 scoreboard objectives add parkour.checkpoint dummy
 scoreboard objectives add parkour.leaderboard_blacklist dummy
 scoreboard objectives add parkour.node_id dummy
-scoreboard objectives add parkour_1.best_time dummy
-scoreboard objectives add parkour_2.best_time dummy
+scoreboard objectives add parkour_1.best_time dummy {"text":"parkour_1.best_time","color":"gold"}
+scoreboard objectives add parkour_2.best_time dummy {"text":"parkour_2.best_time","color":"gold"}
 scoreboard objectives add parkour_2.saved_time dummy
 scoreboard objectives add parkour_2.saved_checkpoint dummy
 scoreboard objectives add parkour_2.saved_x dummy
@@ -283,6 +282,10 @@ scoreboard players reset * gameplay_perms
 scoreboard players reset * staff_perms
 scoreboard players reset * suspicious_ip
 scoreboard players reset * temp_1
+
+scoreboard players reset * afk.last_r0
+scoreboard players reset * afk.last_r1
+scoreboard players reset * afk.time
 
 scoreboard players reset * selected_player
 scoreboard players reset * selected_block.x


### PR DESCRIPTION
If the player's rotation does not change for more than 5 minutes, their playtimes stop increasing.